### PR TITLE
feat: domain model v12 — exercise slots & options

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -24,6 +24,12 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
+        name="calendar"
+        options={{
+          title: 'Calendar',
+        }}
+      />
+      <Tabs.Screen
         name="exercises"
         options={{
           title: 'Exercises',

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -1,0 +1,191 @@
+/** Calendar screen - monthly view of completed workouts with day drill-down. */
+import React, { useState } from 'react';
+import { View, Text, Pressable, ScrollView, ActivityIndicator } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useWorkoutsByMonth } from '@frontend/hooks/useHistory';
+import { parseUTCTimestamp, formatDuration } from '@shared/utils/formatting';
+import type { WorkoutSummary } from '@shared/types/workout';
+
+const WEEKDAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+function getDaysInMonth(year: number, month: number): number {
+  return new Date(year, month, 0).getDate();
+}
+
+function getFirstWeekday(year: number, month: number): number {
+  // Returns 0=Mon, 6=Sun
+  const day = new Date(year, month - 1, 1).getDay();
+  return day === 0 ? 6 : day - 1;
+}
+
+export default function CalendarScreen() {
+  const today = new Date();
+  const [year, setYear] = useState(today.getFullYear());
+  const [month, setMonth] = useState(today.getMonth() + 1); // 1-indexed
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+
+  const { data: workouts, isLoading } = useWorkoutsByMonth(year, month);
+
+  // Build a map: 'YYYY-MM-DD' -> WorkoutSummary[]
+  const workoutsByDay = React.useMemo(() => {
+    const map = new Map<string, WorkoutSummary[]>();
+    for (const w of workouts ?? []) {
+      const d = parseUTCTimestamp(w.startedAt);
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(w);
+    }
+    return map;
+  }, [workouts]);
+
+  const selectedWorkouts = selectedDate ? (workoutsByDay.get(selectedDate) ?? []) : [];
+
+  const daysInMonth = getDaysInMonth(year, month);
+  const firstWeekday = getFirstWeekday(year, month);
+
+  const prevMonth = () => {
+    if (month === 1) { setYear(y => y - 1); setMonth(12); }
+    else setMonth(m => m - 1);
+    setSelectedDate(null);
+  };
+
+  const nextMonth = () => {
+    if (month === 12) { setYear(y => y + 1); setMonth(1); }
+    else setMonth(m => m + 1);
+    setSelectedDate(null);
+  };
+
+  const todayKey = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+
+  // Build grid cells: nulls for empty prefix slots, then day numbers
+  const cells: (number | null)[] = [
+    ...Array(firstWeekday).fill(null),
+    ...Array.from({ length: daysInMonth }, (_, i) => i + 1),
+  ];
+  // Pad to complete last row
+  while (cells.length % 7 !== 0) cells.push(null);
+
+  return (
+    <View className="flex-1 bg-background">
+      <View className="px-4 py-3">
+        <Text className="text-2xl font-bold text-foreground">Calendar</Text>
+      </View>
+
+      {/* Month navigation */}
+      <View className="flex-row items-center justify-between px-4 py-2">
+        <Pressable onPress={prevMonth} className="p-2 rounded-lg bg-background-50">
+          <Ionicons name="chevron-back" size={20} color="rgb(163, 163, 163)" />
+        </Pressable>
+        <Text className="text-base font-semibold text-foreground">
+          {MONTH_NAMES[month - 1]} {year}
+        </Text>
+        <Pressable onPress={nextMonth} className="p-2 rounded-lg bg-background-50">
+          <Ionicons name="chevron-forward" size={20} color="rgb(163, 163, 163)" />
+        </Pressable>
+      </View>
+
+      {/* Weekday headers */}
+      <View className="flex-row px-4 mb-1">
+        {WEEKDAYS.map((d) => (
+          <View key={d} className="flex-1 items-center">
+            <Text className="text-xs font-medium text-foreground-subtle">{d}</Text>
+          </View>
+        ))}
+      </View>
+
+      {/* Calendar grid */}
+      {isLoading ? (
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator color="rgb(52, 211, 153)" />
+        </View>
+      ) : (
+        <ScrollView className="flex-1" contentContainerClassName="pb-[100px]">
+          <View className="px-4">
+            {Array.from({ length: cells.length / 7 }, (_, rowIdx) => (
+              <View key={rowIdx} className="flex-row mb-1">
+                {cells.slice(rowIdx * 7, rowIdx * 7 + 7).map((day, colIdx) => {
+                  if (day === null) {
+                    return <View key={colIdx} className="flex-1 aspect-square" />;
+                  }
+                  const pad = (n: number) => String(n).padStart(2, '0');
+                  const dateKey = `${year}-${pad(month)}-${pad(day)}`;
+                  const hasWorkout = workoutsByDay.has(dateKey);
+                  const isToday = dateKey === todayKey;
+                  const isSelected = dateKey === selectedDate;
+
+                  return (
+                    <Pressable
+                      key={colIdx}
+                      onPress={() => setSelectedDate(isSelected ? null : dateKey)}
+                      className="flex-1 aspect-square items-center justify-center mx-0.5 rounded-lg"
+                      style={isSelected ? { backgroundColor: 'rgb(52, 211, 153)' } : isToday ? { backgroundColor: 'rgba(52, 211, 153, 0.15)' } : undefined}
+                    >
+                      <Text className={`text-sm font-medium ${isSelected ? 'text-background' : isToday ? 'text-primary' : 'text-foreground'}`}>
+                        {day}
+                      </Text>
+                      {hasWorkout && (
+                        <View className={`mt-0.5 h-1.5 w-1.5 rounded-full ${isSelected ? 'bg-background' : 'bg-primary'}`} />
+                      )}
+                    </Pressable>
+                  );
+                })}
+              </View>
+            ))}
+          </View>
+
+          {/* Selected day workouts */}
+          {selectedDate && (
+            <View className="px-4 mt-4">
+              <Text className="text-sm font-semibold text-foreground mb-3">
+                {selectedDate}
+              </Text>
+              {selectedWorkouts.length === 0 ? (
+                <View className="rounded-xl bg-background-50 p-4 items-center">
+                  <Text className="text-sm text-foreground-muted">No workouts on this day</Text>
+                </View>
+              ) : (
+                selectedWorkouts.map((w) => {
+                  const duration = w.elapsedSeconds > 0
+                    ? w.elapsedSeconds
+                    : w.completedAt
+                      ? Math.floor((parseUTCTimestamp(w.completedAt).getTime() - parseUTCTimestamp(w.startedAt).getTime()) / 1000)
+                      : 0;
+                  return (
+                    <View key={w.id} className="mb-3 rounded-xl bg-background-50 p-4">
+                      <View className="flex-row items-center justify-between mb-2">
+                        <Text className="text-base font-semibold text-foreground flex-1">
+                          {w.name || w.workoutTypeName}
+                        </Text>
+                        <View className="rounded-md bg-primary/15 px-2 py-1">
+                          <Text className="text-xs font-medium text-primary">{w.workoutTypeName}</Text>
+                        </View>
+                      </View>
+                      <View className="flex-row gap-4">
+                        <View className="flex-row items-center gap-1">
+                          <Ionicons name="time-outline" size={13} color="rgb(163, 163, 163)" />
+                          <Text className="text-xs text-foreground-muted">{formatDuration(duration)}</Text>
+                        </View>
+                        <View className="flex-row items-center gap-1">
+                          <Ionicons name="barbell-outline" size={13} color="rgb(163, 163, 163)" />
+                          <Text className="text-xs text-foreground-muted">{w.exerciseCount} exercises</Text>
+                        </View>
+                        <View className="flex-row items-center gap-1">
+                          <Ionicons name="layers-outline" size={13} color="rgb(163, 163, 163)" />
+                          <Text className="text-xs text-foreground-muted">{w.setCount} sets</Text>
+                        </View>
+                      </View>
+                    </View>
+                  );
+                })
+              )}
+            </View>
+          )}
+        </ScrollView>
+      )}
+    </View>
+  );
+}

--- a/app/(tabs)/workouts.tsx
+++ b/app/(tabs)/workouts.tsx
@@ -6,7 +6,7 @@ import { WorkoutCard } from '@frontend/components/workout/WorkoutCard';
 import { EmptyState } from '@frontend/components/EmptyState';
 import { ConfirmDialog } from '@frontend/components/overlay/ConfirmDialog';
 import { useWorkoutHistory, useWorkoutGroupDetails } from '@frontend/hooks/useHistory';
-import { useRepeatWorkout, useDeleteWorkout, useDeleteWorkouts, useContinueWorkout, useForceContinueWorkout, useUpdateWorkoutName } from '@frontend/hooks/useWorkout';
+import { useRepeatWorkout, useDeleteWorkout, useDeleteWorkouts, useContinueWorkout, useForceContinueWorkout, useUpdateWorkoutName, useMoveSeriesUp, useMoveSeriesDown } from '@frontend/hooks/useWorkout';
 import { useRouter } from 'expo-router';
 import { formatDate, formatDuration, parseUTCTimestamp } from '@shared/utils/formatting';
 import { cn } from '@frontend/lib/utils';
@@ -51,6 +51,7 @@ function groupWorkouts(workouts: WorkoutSummary[]): WorkoutGroup[] {
     } else {
       map.set(key, {
         key,
+        seriesId: w.seriesId,
         displayName: baseName,
         workoutTypeName: w.workoutTypeName,
         latest: w,
@@ -71,6 +72,8 @@ export default function WorkoutsScreen() {
 
   const continueWorkout = useContinueWorkout();
   const forceContinueWorkout = useForceContinueWorkout();
+  const moveSeriesUp = useMoveSeriesUp();
+  const moveSeriesDown = useMoveSeriesDown();
 
   const [selectedGroup, setSelectedGroup] = useState<WorkoutGroup | null>(null);
   const [confirmDeleteGroup, setConfirmDeleteGroup] = useState<WorkoutGroup | null>(null);
@@ -92,6 +95,20 @@ export default function WorkoutsScreen() {
   );
 
   const groups = useMemo(() => groupWorkouts(workouts), [workouts]);
+
+  // Keep selectedGroup in sync with live data after mutations (delete, rename, etc.)
+  useEffect(() => {
+    if (!selectedGroup) return;
+    const fresh = groups.find((g) => g.key === selectedGroup.key);
+    if (!fresh) {
+      setSelectedGroup(null);
+    } else if (
+      fresh.latest.id !== selectedGroup.latest.id ||
+      fresh.sessions.length !== selectedGroup.sessions.length
+    ) {
+      setSelectedGroup(fresh);
+    }
+  }, [groups]);
 
   // Reset editing state when selected group changes
   useEffect(() => {
@@ -179,15 +196,35 @@ export default function WorkoutsScreen() {
             </View>
           ) : null
         }
-        renderItem={({ item }) => (
-          <WorkoutCard
-            workout={item.latest}
-            sessionCount={item.sessions.length}
-            onPress={() => setSelectedGroup(item)}
-            onRepeat={() => handleRepeat(item.latest.id)}
-            onDelete={() => setConfirmDeleteGroup(item)}
-            onEdit={(name) => updateWorkoutName.mutate({ workoutId: item.latest.id, name })}
-          />
+        renderItem={({ item, index }) => (
+          <View className="flex-row items-center">
+            <View className="flex-1">
+              <WorkoutCard
+                workout={item.latest}
+                sessionCount={item.sessions.length}
+                onPress={() => setSelectedGroup(item)}
+                onRepeat={() => handleRepeat(item.latest.id)}
+                onDelete={() => setConfirmDeleteGroup(item)}
+                onEdit={(name) => updateWorkoutName.mutate({ workoutId: item.latest.id, name })}
+              />
+            </View>
+            <View className="ml-1.5 flex-col justify-center gap-1">
+              <Pressable
+                onPress={() => item.seriesId && moveSeriesUp.mutate(item.seriesId)}
+                disabled={index === 0}
+                className="p-2 rounded-lg bg-background-50"
+              >
+                <Ionicons name="chevron-up" size={16} color={index === 0 ? 'rgb(64, 64, 64)' : 'rgb(163, 163, 163)'} />
+              </Pressable>
+              <Pressable
+                onPress={() => item.seriesId && moveSeriesDown.mutate(item.seriesId)}
+                disabled={index === groups.length - 1}
+                className="p-2 rounded-lg bg-background-50"
+              >
+                <Ionicons name="chevron-down" size={16} color={index === groups.length - 1 ? 'rgb(64, 64, 64)' : 'rgb(163, 163, 163)'} />
+              </Pressable>
+            </View>
+          </View>
         )}
       />
 

--- a/app/workout/[id].tsx
+++ b/app/workout/[id].tsx
@@ -28,6 +28,7 @@ import {
   useDisbandSuperset,
   useUpdateSupersetRestSeconds,
   useLogSupersetRound,
+  useSwitchWorkoutExercise,
 } from '@frontend/hooks/useWorkout';
 import { usePreviousSetsForExercises } from '@frontend/hooks/useHistory';
 import { ExerciseCategory } from '@shared/types/exercise';
@@ -75,6 +76,7 @@ function ActiveWorkoutContent({ workout, id }: { workout: WorkoutFull; id: strin
   const discardWorkout = useDiscardWorkout();
   const updateRestSeconds = useUpdateWorkoutExerciseRestSeconds(id);
   const updateTargetReps = useUpdateExerciseTargetReps(id);
+  const switchExercise = useSwitchWorkoutExercise(id);
   const makeSuperset = useMakeSuperset(id);
   const addToSuperset = useAddExerciseToSuperset(id);
   const disbandSuperset = useDisbandSuperset(id);
@@ -181,6 +183,7 @@ function ActiveWorkoutContent({ workout, id }: { workout: WorkoutFull; id: strin
                   key={ex.id}
                   exercise={ex}
                   isStrength={isStrength}
+                  seriesId={workout.seriesId}
                   previousSets={previousSetsMap?.get(ex.exerciseId)}
                   onMoveUp={!isFirst ? () => handleMoveItem(renderIndex, 'up') : undefined}
                   onMoveDown={!isLast ? () => handleMoveItem(renderIndex, 'down') : undefined}
@@ -197,6 +200,9 @@ function ActiveWorkoutContent({ workout, id }: { workout: WorkoutFull; id: strin
                   }
                   onMakeSuperset={() =>
                     setPickerMode({ type: 'makeSuperset', workoutExerciseId: ex.id })
+                  }
+                  onSwitchToAlternative={(workoutExerciseId, newExerciseId) =>
+                    switchExercise.mutate({ workoutExerciseId, newExerciseId })
                   }
                 />
               );

--- a/src/backend/database/migrations.ts
+++ b/src/backend/database/migrations.ts
@@ -210,6 +210,157 @@ const migrations: Migration[] = [
       );
     }
   },
+  // v8 -> v9: Add sort_order to workout_series for manual ordering
+  async (db) => {
+    await db.execAsync(`
+      ALTER TABLE workout_series ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0;
+    `);
+    // Initialize: oldest series gets sort_order 1, newest gets N (sorted DESC = newest at top)
+    await db.execAsync(`
+      UPDATE workout_series
+      SET sort_order = (
+        SELECT COUNT(*) FROM workout_series ws2
+        WHERE ws2.created_at < workout_series.created_at
+          OR (ws2.created_at = workout_series.created_at AND ws2.id <= workout_series.id)
+      );
+    `);
+  },
+  // v9 -> v10: Add series_exercise_alternatives for per-series alternative exercises
+  async (db) => {
+    await db.execAsync(`
+      CREATE TABLE IF NOT EXISTS series_exercise_alternatives (
+        id TEXT PRIMARY KEY,
+        series_id TEXT NOT NULL REFERENCES workout_series(id) ON DELETE CASCADE,
+        exercise_id TEXT NOT NULL REFERENCES exercises(id) ON DELETE CASCADE,
+        alternative_exercise_id TEXT NOT NULL REFERENCES exercises(id) ON DELETE CASCADE,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE(series_id, exercise_id, alternative_exercise_id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_sea_series_exercise ON series_exercise_alternatives(series_id, exercise_id);
+    `);
+  },
+  // v10 -> v11: Replace series+exercise keyed alternatives with stable slot_id per exercise position
+  async (db) => {
+    // Add slot_id to workout_exercises; backfill existing rows with their own id
+    await db.execAsync(`ALTER TABLE workout_exercises ADD COLUMN slot_id TEXT NOT NULL DEFAULT '';`);
+    await db.execAsync(`UPDATE workout_exercises SET slot_id = id;`);
+    // Drop old alternatives table (keyed by series+exercise, breaks after switching exercises)
+    await db.execAsync(`DROP TABLE IF EXISTS series_exercise_alternatives;`);
+    // New table keyed by stable slot_id
+    await db.execAsync(`
+      CREATE TABLE IF NOT EXISTS exercise_slot_alternatives (
+        id TEXT PRIMARY KEY,
+        slot_id TEXT NOT NULL,
+        alternative_exercise_id TEXT NOT NULL REFERENCES exercises(id) ON DELETE CASCADE,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE(slot_id, alternative_exercise_id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_esa_slot ON exercise_slot_alternatives(slot_id);
+    `);
+  },
+  // v11 -> v12: Add exercise_slots and exercise_options as first-class tables
+  async (db) => {
+    // Step 1: Create new tables and add exercise_option_id column
+    await db.execAsync(`
+      CREATE TABLE exercise_slots (
+        id TEXT PRIMARY KEY,
+        series_id TEXT NOT NULL REFERENCES workout_series(id) ON DELETE CASCADE,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      CREATE INDEX idx_exercise_slots_series ON exercise_slots(series_id);
+
+      CREATE TABLE exercise_options (
+        id TEXT PRIMARY KEY,
+        slot_id TEXT NOT NULL REFERENCES exercise_slots(id) ON DELETE CASCADE,
+        exercise_id TEXT NOT NULL REFERENCES exercises(id) ON DELETE CASCADE,
+        is_primary INTEGER NOT NULL DEFAULT 0,
+        rest_seconds INTEGER NOT NULL DEFAULT 90,
+        target_reps_min INTEGER DEFAULT NULL,
+        target_reps_max INTEGER DEFAULT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE(slot_id, exercise_id)
+      );
+      CREATE INDEX idx_exercise_options_slot ON exercise_options(slot_id);
+
+      ALTER TABLE workout_exercises ADD COLUMN exercise_option_id TEXT
+        REFERENCES exercise_options(id) ON DELETE SET NULL;
+    `);
+
+    // Step 2: Backfill exercise_slots (one per unique slot_id, inherit series from workout)
+    await db.execAsync(`
+      INSERT INTO exercise_slots (id, series_id, sort_order, created_at)
+      SELECT we.slot_id, w.series_id, MIN(we.sort_order), MIN(we.created_at)
+      FROM workout_exercises we
+      JOIN workouts w ON w.id = we.workout_id
+      WHERE we.slot_id != '' AND w.series_id IS NOT NULL
+      GROUP BY we.slot_id;
+    `);
+
+    // Step 3: Backfill exercise_options from workout_exercises (latest settings per slot+exercise)
+    const uniquePairs = await db.getAllAsync<{ slot_id: string; exercise_id: string }>(
+      `SELECT DISTINCT slot_id, exercise_id FROM workout_exercises
+       WHERE slot_id != '' AND EXISTS (SELECT 1 FROM exercise_slots WHERE id = slot_id)`
+    );
+    for (const pair of uniquePairs) {
+      const latest = await db.getFirstAsync<{
+        rest_seconds: number;
+        target_reps_min: number | null;
+        target_reps_max: number | null;
+        created_at: string;
+      }>(
+        `SELECT we.rest_seconds, we.target_reps_min, we.target_reps_max, we.created_at
+         FROM workout_exercises we
+         JOIN workouts w ON w.id = we.workout_id
+         WHERE we.slot_id = ? AND we.exercise_id = ?
+         ORDER BY w.started_at DESC LIMIT 1`,
+        pair.slot_id, pair.exercise_id
+      );
+      if (latest) {
+        await db.runAsync(
+          `INSERT OR IGNORE INTO exercise_options
+             (id, slot_id, exercise_id, is_primary, rest_seconds, target_reps_min, target_reps_max, created_at)
+           VALUES (?, ?, ?, 1, ?, ?, ?, ?)`,
+          Crypto.randomUUID(), pair.slot_id, pair.exercise_id,
+          latest.rest_seconds, latest.target_reps_min, latest.target_reps_max, latest.created_at
+        );
+      }
+    }
+
+    // Step 4: Backfill exercise_options from exercise_slot_alternatives (as non-primary)
+    const alternatives = await db.getAllAsync<{
+      slot_id: string;
+      alternative_exercise_id: string;
+      created_at: string;
+    }>(
+      `SELECT esa.slot_id, esa.alternative_exercise_id, esa.created_at
+       FROM exercise_slot_alternatives esa
+       WHERE EXISTS (SELECT 1 FROM exercise_slots WHERE id = esa.slot_id)`
+    );
+    for (const alt of alternatives) {
+      const primaryRest = await db.getFirstAsync<{ rest_seconds: number }>(
+        `SELECT rest_seconds FROM exercise_options WHERE slot_id = ? AND is_primary = 1 LIMIT 1`,
+        alt.slot_id
+      );
+      await db.runAsync(
+        `INSERT OR IGNORE INTO exercise_options
+           (id, slot_id, exercise_id, is_primary, rest_seconds, created_at)
+         VALUES (?, ?, ?, 0, ?, ?)`,
+        Crypto.randomUUID(), alt.slot_id, alt.alternative_exercise_id,
+        primaryRest?.rest_seconds ?? 90, alt.created_at
+      );
+    }
+
+    // Step 5: Populate exercise_option_id on existing workout_exercises
+    await db.execAsync(`
+      UPDATE workout_exercises SET exercise_option_id = (
+        SELECT eo.id FROM exercise_options eo
+        WHERE eo.slot_id = workout_exercises.slot_id
+          AND eo.exercise_id = workout_exercises.exercise_id
+        LIMIT 1
+      );
+    `);
+  },
 ];
 
 export async function runMigrations(db: SQLite.SQLiteDatabase): Promise<void> {

--- a/src/backend/models/exerciseAlternative.ts
+++ b/src/backend/models/exerciseAlternative.ts
@@ -1,0 +1,81 @@
+/** ExerciseAlternative model - manages per-slot alternative exercises. */
+import type * as SQLite from 'expo-sqlite';
+import * as Crypto from 'expo-crypto';
+
+export interface ExerciseAlternativeRow {
+  id: string;
+  slot_id: string;
+  alternative_exercise_id: string;
+  alternative_name: string;
+  created_at: string;
+}
+
+export interface ExerciseAlternative {
+  id: string;
+  slotId: string;
+  alternativeExerciseId: string;
+  alternativeName: string;
+  createdAt: string;
+}
+
+export async function getAlternatives(
+  db: SQLite.SQLiteDatabase,
+  slotId: string
+): Promise<ExerciseAlternative[]> {
+  const rows = await db.getAllAsync<ExerciseAlternativeRow>(
+    `SELECT esa.id, esa.slot_id, esa.alternative_exercise_id,
+            e.name AS alternative_name, esa.created_at
+     FROM exercise_slot_alternatives esa
+     JOIN exercises e ON e.id = esa.alternative_exercise_id
+     WHERE esa.slot_id = ?
+     ORDER BY esa.created_at ASC`,
+    slotId
+  );
+  return rows.map((r) => ({
+    id: r.id,
+    slotId: r.slot_id,
+    alternativeExerciseId: r.alternative_exercise_id,
+    alternativeName: r.alternative_name,
+    createdAt: r.created_at,
+  }));
+}
+
+export async function addAlternative(
+  db: SQLite.SQLiteDatabase,
+  slotId: string,
+  alternativeExerciseId: string
+): Promise<ExerciseAlternative> {
+  const id = Crypto.randomUUID();
+  await db.runAsync(
+    `INSERT OR IGNORE INTO exercise_slot_alternatives
+       (id, slot_id, alternative_exercise_id)
+     VALUES (?, ?, ?)`,
+    id,
+    slotId,
+    alternativeExerciseId
+  );
+  const row = await db.getFirstAsync<ExerciseAlternativeRow>(
+    `SELECT esa.id, esa.slot_id, esa.alternative_exercise_id,
+            e.name AS alternative_name, esa.created_at
+     FROM exercise_slot_alternatives esa
+     JOIN exercises e ON e.id = esa.alternative_exercise_id
+     WHERE esa.slot_id = ? AND esa.alternative_exercise_id = ?`,
+    slotId,
+    alternativeExerciseId
+  );
+  if (!row) throw new Error('Failed to add alternative exercise');
+  return {
+    id: row.id,
+    slotId: row.slot_id,
+    alternativeExerciseId: row.alternative_exercise_id,
+    alternativeName: row.alternative_name,
+    createdAt: row.created_at,
+  };
+}
+
+export async function removeAlternative(
+  db: SQLite.SQLiteDatabase,
+  id: string
+): Promise<void> {
+  await db.runAsync(`DELETE FROM exercise_slot_alternatives WHERE id = ?`, id);
+}

--- a/src/backend/models/exerciseOption.ts
+++ b/src/backend/models/exerciseOption.ts
@@ -1,0 +1,119 @@
+/** ExerciseOption model - manages exercise options (primary + alternatives) within a slot. */
+import type * as SQLite from 'expo-sqlite';
+import * as Crypto from 'expo-crypto';
+import type { ExerciseOption } from '@shared/types/workout';
+
+interface ExerciseOptionRow {
+  id: string;
+  slot_id: string;
+  exercise_id: string;
+  is_primary: number;
+  rest_seconds: number;
+  target_reps_min: number | null;
+  target_reps_max: number | null;
+  created_at: string;
+}
+
+function mapRow(row: ExerciseOptionRow): ExerciseOption {
+  return {
+    id: row.id,
+    slotId: row.slot_id,
+    exerciseId: row.exercise_id,
+    isPrimary: row.is_primary === 1,
+    restSeconds: row.rest_seconds,
+    targetRepsMin: row.target_reps_min,
+    targetRepsMax: row.target_reps_max,
+    createdAt: row.created_at,
+  };
+}
+
+export async function create(
+  db: SQLite.SQLiteDatabase,
+  slotId: string,
+  exerciseId: string,
+  isPrimary: boolean,
+  restSeconds: number,
+  targetRepsMin?: number | null,
+  targetRepsMax?: number | null
+): Promise<ExerciseOption> {
+  const id = Crypto.randomUUID();
+  await db.runAsync(
+    `INSERT INTO exercise_options (id, slot_id, exercise_id, is_primary, rest_seconds, target_reps_min, target_reps_max)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    id, slotId, exerciseId, isPrimary ? 1 : 0, restSeconds,
+    targetRepsMin ?? null, targetRepsMax ?? null
+  );
+  const row = await db.getFirstAsync<ExerciseOptionRow>(
+    `SELECT * FROM exercise_options WHERE id = ?`, id
+  );
+  if (!row) throw new Error(`Failed to create exercise option, id ${id}`);
+  return mapRow(row);
+}
+
+export async function getById(
+  db: SQLite.SQLiteDatabase,
+  id: string
+): Promise<ExerciseOption | null> {
+  const row = await db.getFirstAsync<ExerciseOptionRow>(
+    `SELECT * FROM exercise_options WHERE id = ?`, id
+  );
+  return row ? mapRow(row) : null;
+}
+
+export async function getBySlot(
+  db: SQLite.SQLiteDatabase,
+  slotId: string
+): Promise<ExerciseOption[]> {
+  const rows = await db.getAllAsync<ExerciseOptionRow>(
+    `SELECT * FROM exercise_options WHERE slot_id = ? ORDER BY is_primary DESC`, slotId
+  );
+  return rows.map(mapRow);
+}
+
+export async function getBySlotAndExercise(
+  db: SQLite.SQLiteDatabase,
+  slotId: string,
+  exerciseId: string
+): Promise<ExerciseOption | null> {
+  const row = await db.getFirstAsync<ExerciseOptionRow>(
+    `SELECT * FROM exercise_options WHERE slot_id = ? AND exercise_id = ?`,
+    slotId, exerciseId
+  );
+  return row ? mapRow(row) : null;
+}
+
+export async function ensureExists(
+  db: SQLite.SQLiteDatabase,
+  slotId: string,
+  exerciseId: string,
+  isPrimary: boolean,
+  restSeconds: number,
+  targetRepsMin?: number | null,
+  targetRepsMax?: number | null
+): Promise<ExerciseOption> {
+  const existing = await getBySlotAndExercise(db, slotId, exerciseId);
+  if (existing) return existing;
+  return create(db, slotId, exerciseId, isPrimary, restSeconds, targetRepsMin, targetRepsMax);
+}
+
+export async function updateRestSeconds(
+  db: SQLite.SQLiteDatabase,
+  id: string,
+  restSeconds: number
+): Promise<void> {
+  await db.runAsync(
+    `UPDATE exercise_options SET rest_seconds = ? WHERE id = ?`, restSeconds, id
+  );
+}
+
+export async function updateTargetReps(
+  db: SQLite.SQLiteDatabase,
+  id: string,
+  targetRepsMin: number | null,
+  targetRepsMax: number | null
+): Promise<void> {
+  await db.runAsync(
+    `UPDATE exercise_options SET target_reps_min = ?, target_reps_max = ? WHERE id = ?`,
+    targetRepsMin, targetRepsMax, id
+  );
+}

--- a/src/backend/models/exerciseSlot.ts
+++ b/src/backend/models/exerciseSlot.ts
@@ -1,0 +1,66 @@
+/** ExerciseSlot model - manages exercise slot positions within a workout series. */
+import type * as SQLite from 'expo-sqlite';
+import type { ExerciseSlot } from '@shared/types/workout';
+
+interface ExerciseSlotRow {
+  id: string;
+  series_id: string;
+  sort_order: number;
+  created_at: string;
+}
+
+function mapRow(row: ExerciseSlotRow): ExerciseSlot {
+  return {
+    id: row.id,
+    seriesId: row.series_id,
+    sortOrder: row.sort_order,
+    createdAt: row.created_at,
+  };
+}
+
+export async function create(
+  db: SQLite.SQLiteDatabase,
+  id: string,
+  seriesId: string,
+  sortOrder = 0
+): Promise<ExerciseSlot> {
+  await db.runAsync(
+    `INSERT INTO exercise_slots (id, series_id, sort_order) VALUES (?, ?, ?)`,
+    id, seriesId, sortOrder
+  );
+  const row = await db.getFirstAsync<ExerciseSlotRow>(
+    `SELECT * FROM exercise_slots WHERE id = ?`, id
+  );
+  if (!row) throw new Error(`Failed to create exercise slot, id ${id}`);
+  return mapRow(row);
+}
+
+export async function getById(
+  db: SQLite.SQLiteDatabase,
+  id: string
+): Promise<ExerciseSlot | null> {
+  const row = await db.getFirstAsync<ExerciseSlotRow>(
+    `SELECT * FROM exercise_slots WHERE id = ?`, id
+  );
+  return row ? mapRow(row) : null;
+}
+
+export async function getBySeries(
+  db: SQLite.SQLiteDatabase,
+  seriesId: string
+): Promise<ExerciseSlot[]> {
+  const rows = await db.getAllAsync<ExerciseSlotRow>(
+    `SELECT * FROM exercise_slots WHERE series_id = ? ORDER BY sort_order`, seriesId
+  );
+  return rows.map(mapRow);
+}
+
+export async function ensureExists(
+  db: SQLite.SQLiteDatabase,
+  slotId: string,
+  seriesId: string
+): Promise<ExerciseSlot> {
+  const existing = await getById(db, slotId);
+  if (existing) return existing;
+  return create(db, slotId, seriesId);
+}

--- a/src/backend/models/workoutExercise.ts
+++ b/src/backend/models/workoutExercise.ts
@@ -10,6 +10,8 @@ interface WorkoutExerciseRow {
   id: string;
   workout_id: string;
   exercise_id: string;
+  slot_id: string;
+  exercise_option_id: string | null;
   sort_order: number;
   rest_seconds: number;
   target_reps_min: number | null;
@@ -30,6 +32,8 @@ function mapRow(row: WorkoutExerciseRow): WorkoutExercise {
     id: row.id,
     workoutId: row.workout_id,
     exerciseId: row.exercise_id,
+    slotId: row.slot_id,
+    exerciseOptionId: row.exercise_option_id,
     sortOrder: row.sort_order,
     restSeconds: row.rest_seconds,
     targetRepsMin: row.target_reps_min,
@@ -56,24 +60,29 @@ export async function addToWorkout(
   exerciseId: string,
   restSeconds: number,
   targetRepsMin?: number | null,
-  targetRepsMax?: number | null
+  targetRepsMax?: number | null,
+  slotId?: string,
+  exerciseOptionId?: string | null
 ): Promise<WorkoutExercise> {
   const id = Crypto.randomUUID();
+  const resolvedSlotId = slotId ?? id;
   await db.runAsync(
-    `INSERT INTO workout_exercises (id, workout_id, exercise_id, sort_order, rest_seconds, target_reps_min, target_reps_max, created_at)
+    `INSERT INTO workout_exercises (id, workout_id, exercise_id, slot_id, sort_order, rest_seconds, target_reps_min, target_reps_max, exercise_option_id, created_at)
      VALUES (
-       ?, ?, ?,
+       ?, ?, ?, ?,
        COALESCE((SELECT MAX(sort_order) + 1 FROM workout_exercises WHERE workout_id = ?), 0),
-       ?, ?, ?,
+       ?, ?, ?, ?,
        datetime('now')
      )`,
     id,
     workoutId,
     exerciseId,
+    resolvedSlotId,
     workoutId,
     restSeconds,
     targetRepsMin ?? null,
-    targetRepsMax ?? null
+    targetRepsMax ?? null,
+    exerciseOptionId ?? null
   );
   const row = await db.getFirstAsync<WorkoutExerciseRow>(
     `SELECT * FROM workout_exercises WHERE id = ?`,
@@ -117,6 +126,18 @@ export async function removeFromWorkout(
   });
 }
 
+export async function updateExerciseId(
+  db: SQLite.SQLiteDatabase,
+  id: string,
+  newExerciseId: string
+): Promise<void> {
+  await db.runAsync(
+    `UPDATE workout_exercises SET exercise_id = ? WHERE id = ?`,
+    newExerciseId,
+    id
+  );
+}
+
 export async function updateRestSeconds(
   db: SQLite.SQLiteDatabase,
   id: string,
@@ -139,6 +160,18 @@ export async function updateTargetReps(
     `UPDATE workout_exercises SET target_reps_min = ?, target_reps_max = ? WHERE id = ?`,
     targetRepsMin,
     targetRepsMax,
+    id
+  );
+}
+
+export async function updateExerciseOptionId(
+  db: SQLite.SQLiteDatabase,
+  id: string,
+  exerciseOptionId: string | null
+): Promise<void> {
+  await db.runAsync(
+    `UPDATE workout_exercises SET exercise_option_id = ? WHERE id = ?`,
+    exerciseOptionId,
     id
   );
 }

--- a/src/backend/models/workoutSeries.ts
+++ b/src/backend/models/workoutSeries.ts
@@ -6,6 +6,7 @@ import type { WorkoutSeries } from '@shared/types/workout';
 interface WorkoutSeriesRow {
   id: string;
   name: string;
+  sort_order: number;
   created_at: string;
 }
 
@@ -13,6 +14,7 @@ function mapRow(row: WorkoutSeriesRow): WorkoutSeries {
   return {
     id: row.id,
     name: row.name,
+    sortOrder: row.sort_order,
     createdAt: row.created_at,
   };
 }
@@ -23,7 +25,8 @@ export async function create(
 ): Promise<WorkoutSeries> {
   const id = Crypto.randomUUID();
   await db.runAsync(
-    `INSERT INTO workout_series (id, name, created_at) VALUES (?, ?, datetime('now'))`,
+    `INSERT INTO workout_series (id, name, sort_order, created_at)
+     VALUES (?, ?, (SELECT COALESCE(MAX(sort_order), 0) + 1 FROM workout_series), datetime('now'))`,
     id,
     name
   );
@@ -52,4 +55,35 @@ export async function updateName(
   name: string
 ): Promise<void> {
   await db.runAsync(`UPDATE workout_series SET name = ? WHERE id = ?`, name, id);
+}
+
+export async function moveUp(
+  db: SQLite.SQLiteDatabase,
+  seriesId: string
+): Promise<void> {
+  // Sorted DESC = highest sort_order at top. moveUp = swap with neighbor that has higher sort_order
+  const all = await db.getAllAsync<{ id: string; sort_order: number }>(
+    `SELECT id, sort_order FROM workout_series ORDER BY sort_order DESC`
+  );
+  const idx = all.findIndex((s) => s.id === seriesId);
+  if (idx <= 0) return;
+  const current = all[idx];
+  const above = all[idx - 1];
+  await db.runAsync(`UPDATE workout_series SET sort_order = ? WHERE id = ?`, above.sort_order, current.id);
+  await db.runAsync(`UPDATE workout_series SET sort_order = ? WHERE id = ?`, current.sort_order, above.id);
+}
+
+export async function moveDown(
+  db: SQLite.SQLiteDatabase,
+  seriesId: string
+): Promise<void> {
+  const all = await db.getAllAsync<{ id: string; sort_order: number }>(
+    `SELECT id, sort_order FROM workout_series ORDER BY sort_order DESC`
+  );
+  const idx = all.findIndex((s) => s.id === seriesId);
+  if (idx < 0 || idx >= all.length - 1) return;
+  const current = all[idx];
+  const below = all[idx + 1];
+  await db.runAsync(`UPDATE workout_series SET sort_order = ? WHERE id = ?`, below.sort_order, current.id);
+  await db.runAsync(`UPDATE workout_series SET sort_order = ? WHERE id = ?`, current.sort_order, below.id);
 }

--- a/src/backend/services/workoutService.ts
+++ b/src/backend/services/workoutService.ts
@@ -1,5 +1,6 @@
 /** Workout service - orchestrates workout lifecycle, set logging, and exercise management. */
 import type * as SQLite from 'expo-sqlite';
+import * as Crypto from 'expo-crypto';
 import * as workout from '@backend/models/workout';
 import * as workoutExercise from '@backend/models/workoutExercise';
 import * as workoutSet from '@backend/models/workoutSet';
@@ -7,6 +8,10 @@ import * as workoutType from '@backend/models/workoutType';
 import * as exercise from '@backend/models/exercise';
 import * as supersetGroupModel from '@backend/models/supersetGroup';
 import * as workoutSeriesModel from '@backend/models/workoutSeries';
+import * as exerciseSlotModel from '@backend/models/exerciseSlot';
+import * as exerciseOptionModel from '@backend/models/exerciseOption';
+import * as exerciseAlternativeModel from '@backend/models/exerciseAlternative';
+import type { ExerciseAlternative } from '@backend/models/exerciseAlternative';
 import { getDefaultRestSeconds } from '@backend/services/timerService';
 import { APP_CONFIG } from '@config/app';
 import { validateWeight, validateReps, validateDuration, validateDistance } from '@shared/utils/validation';
@@ -44,16 +49,28 @@ export async function addExerciseToWorkout(
   exerciseId: string,
   restSeconds?: number,
   targetRepsMin?: number | null,
-  targetRepsMax?: number | null
+  targetRepsMax?: number | null,
+  slotId?: string
 ): Promise<WorkoutExercise> {
-  if (restSeconds != null) {
-    return workoutExercise.addToWorkout(db, workoutId, exerciseId, restSeconds, targetRepsMin, targetRepsMax);
-  }
   const ex = await exercise.getById(db, exerciseId);
-  const resolvedRest = ex
-    ? (ex.restSeconds ?? getDefaultRestSeconds(ex.category))
-    : APP_CONFIG.defaults.restSeconds.strength;
-  return workoutExercise.addToWorkout(db, workoutId, exerciseId, resolvedRest, targetRepsMin, targetRepsMax);
+  const resolvedRest = restSeconds != null
+    ? restSeconds
+    : (ex ? (ex.restSeconds ?? getDefaultRestSeconds(ex.category)) : APP_CONFIG.defaults.restSeconds.strength);
+  const resolvedSlotId = slotId ?? Crypto.randomUUID();
+
+  const w = await workout.getById(db, workoutId);
+  let exerciseOptionId: string | null = null;
+  if (w?.seriesId) {
+    await exerciseSlotModel.ensureExists(db, resolvedSlotId, w.seriesId);
+    const option = await exerciseOptionModel.ensureExists(
+      db, resolvedSlotId, exerciseId, true, resolvedRest, targetRepsMin, targetRepsMax
+    );
+    exerciseOptionId = option.id;
+  }
+
+  return workoutExercise.addToWorkout(
+    db, workoutId, exerciseId, resolvedRest, targetRepsMin, targetRepsMax, resolvedSlotId, exerciseOptionId
+  );
 }
 
 export async function continueWorkout(
@@ -84,7 +101,11 @@ export async function updateWorkoutExerciseRestSeconds(
   workoutExerciseId: string,
   restSeconds: number
 ): Promise<void> {
-  return workoutExercise.updateRestSeconds(db, workoutExerciseId, restSeconds);
+  await workoutExercise.updateRestSeconds(db, workoutExerciseId, restSeconds);
+  const ex = await workoutExercise.getById(db, workoutExerciseId);
+  if (ex?.exerciseOptionId) {
+    await exerciseOptionModel.updateRestSeconds(db, ex.exerciseOptionId, restSeconds);
+  }
 }
 
 export async function updateExerciseTargetReps(
@@ -93,7 +114,11 @@ export async function updateExerciseTargetReps(
   targetRepsMin: number | null,
   targetRepsMax: number | null
 ): Promise<void> {
-  return workoutExercise.updateTargetReps(db, workoutExerciseId, targetRepsMin, targetRepsMax);
+  await workoutExercise.updateTargetReps(db, workoutExerciseId, targetRepsMin, targetRepsMax);
+  const ex = await workoutExercise.getById(db, workoutExerciseId);
+  if (ex?.exerciseOptionId) {
+    await exerciseOptionModel.updateTargetReps(db, ex.exerciseOptionId, targetRepsMin, targetRepsMax);
+  }
 }
 
 export async function logSet(
@@ -326,6 +351,7 @@ export async function getWorkoutSummaries(
 ): Promise<WorkoutSummary[]> {
   type SummaryRow = {
     id: string;
+    series_id: string | null;
     name: string | null;
     workout_type_name: string;
     status: string;
@@ -340,6 +366,7 @@ export async function getWorkoutSummaries(
   const rows = await db.getAllAsync<SummaryRow>(
     `SELECT
        w.id,
+       w.series_id,
        COALESCE(ws_series.name, w.name) AS name,
        wt.name            AS workout_type_name,
        w.status,
@@ -356,7 +383,7 @@ export async function getWorkoutSummaries(
      LEFT JOIN workout_sets ws ON ws.workout_exercise_id = we.id
      WHERE w.status = ?
      GROUP BY w.id
-     ORDER BY w.started_at DESC
+     ORDER BY ws_series.sort_order DESC, ws_series.created_at DESC, w.started_at DESC
      LIMIT ? OFFSET ?`,
     WorkoutStatus.Completed,
     limit,
@@ -387,6 +414,7 @@ export async function getWorkoutSummaries(
 
   return rows.map((row) => ({
     id: row.id,
+    seriesId: row.series_id,
     name: row.name,
     workoutTypeName: row.workout_type_name,
     status: row.status as WorkoutStatus,
@@ -423,7 +451,7 @@ export async function repeatWorkout(
   const groupIdMap = new Map<string, string>();
 
   for (const ex of source.exercises) {
-    const newExercise = await addExerciseToWorkout(db, newWorkout.id, ex.exerciseId, ex.restSeconds, ex.targetRepsMin, ex.targetRepsMax);
+    const newExercise = await addExerciseToWorkout(db, newWorkout.id, ex.exerciseId, ex.restSeconds, ex.targetRepsMin, ex.targetRepsMax, ex.slotId);
 
     if (ex.supersetGroupId) {
       if (!groupIdMap.has(ex.supersetGroupId)) {
@@ -478,4 +506,140 @@ export async function updateWorkoutSeriesName(
   const w = await workout.getById(db, workoutId);
   if (!w?.seriesId) throw new Error('Workout has no associated series');
   return workoutSeriesModel.updateName(db, w.seriesId, name);
+}
+
+export async function moveSeriesUp(
+  db: SQLite.SQLiteDatabase,
+  seriesId: string
+): Promise<void> {
+  return workoutSeriesModel.moveUp(db, seriesId);
+}
+
+export async function moveSeriesDown(
+  db: SQLite.SQLiteDatabase,
+  seriesId: string
+): Promise<void> {
+  return workoutSeriesModel.moveDown(db, seriesId);
+}
+
+export async function getWorkoutSummariesByDateRange(
+  db: SQLite.SQLiteDatabase,
+  startDate: string,
+  endDate: string
+): Promise<WorkoutSummary[]> {
+  type DateRangeSummaryRow = {
+    id: string;
+    series_id: string | null;
+    name: string | null;
+    workout_type_name: string;
+    status: string;
+    started_at: string;
+    completed_at: string | null;
+    exercise_count: number;
+    set_count: number;
+    total_volume: number | null;
+    elapsed_seconds: number;
+  };
+
+  const rows = await db.getAllAsync<DateRangeSummaryRow>(
+    `SELECT
+       w.id,
+       w.series_id,
+       COALESCE(ws_series.name, w.name) AS name,
+       wt.name            AS workout_type_name,
+       w.status,
+       w.started_at,
+       w.completed_at,
+       w.elapsed_seconds,
+       COUNT(DISTINCT we.id)                        AS exercise_count,
+       COUNT(ws.id)                                 AS set_count,
+       COALESCE(SUM(ws.weight_kg * ws.reps), 0)     AS total_volume
+     FROM workouts w
+     JOIN workout_types wt ON wt.id = w.workout_type_id
+     LEFT JOIN workout_series ws_series ON ws_series.id = w.series_id
+     LEFT JOIN workout_exercises we ON we.workout_id = w.id
+     LEFT JOIN workout_sets ws ON ws.workout_exercise_id = we.id
+     WHERE w.status = ? AND w.started_at >= ? AND w.started_at <= ?
+     GROUP BY w.id
+     ORDER BY w.started_at DESC`,
+    WorkoutStatus.Completed,
+    startDate,
+    endDate
+  );
+
+  if (rows.length === 0) return [];
+
+  const workoutIds = rows.map((r) => r.id);
+  const placeholders = workoutIds.map(() => '?').join(', ');
+  const muscleRows = await db.getAllAsync<{ workout_id: string; muscle_group: string; set_count: number }>(
+    `SELECT we.workout_id, jm.value AS muscle_group, COUNT(ws.id) AS set_count
+     FROM workout_exercises we
+     JOIN exercises e ON e.id = we.exercise_id
+     JOIN json_each(e.primary_muscles) jm
+     JOIN workout_sets ws ON ws.workout_exercise_id = we.id
+     WHERE we.workout_id IN (${placeholders})
+     GROUP BY we.workout_id, jm.value`,
+    ...workoutIds
+  );
+
+  const muscleMap = new Map<string, Record<string, number>>();
+  for (const mr of muscleRows) {
+    if (!muscleMap.has(mr.workout_id)) muscleMap.set(mr.workout_id, {});
+    muscleMap.get(mr.workout_id)![mr.muscle_group] = mr.set_count;
+  }
+
+  return rows.map((row) => ({
+    id: row.id,
+    seriesId: row.series_id,
+    name: row.name,
+    workoutTypeName: row.workout_type_name,
+    status: row.status as WorkoutStatus,
+    startedAt: row.started_at,
+    completedAt: row.completed_at,
+    exerciseCount: row.exercise_count,
+    setCount: row.set_count,
+    totalVolume: row.total_volume ?? 0,
+    elapsedSeconds: row.elapsed_seconds,
+    muscleGroupSets: muscleMap.get(row.id) ?? {},
+  }));
+}
+
+export async function getExerciseAlternatives(
+  db: SQLite.SQLiteDatabase,
+  slotId: string
+): Promise<ExerciseAlternative[]> {
+  return exerciseAlternativeModel.getAlternatives(db, slotId);
+}
+
+export async function addExerciseAlternative(
+  db: SQLite.SQLiteDatabase,
+  slotId: string,
+  alternativeExerciseId: string
+): Promise<ExerciseAlternative> {
+  return exerciseAlternativeModel.addAlternative(db, slotId, alternativeExerciseId);
+}
+
+export async function removeExerciseAlternative(
+  db: SQLite.SQLiteDatabase,
+  id: string
+): Promise<void> {
+  return exerciseAlternativeModel.removeAlternative(db, id);
+}
+
+export async function switchWorkoutExercise(
+  db: SQLite.SQLiteDatabase,
+  workoutExerciseId: string,
+  newExerciseId: string
+): Promise<void> {
+  const ex = await workoutExercise.getById(db, workoutExerciseId);
+  await workoutExercise.updateExerciseId(db, workoutExerciseId, newExerciseId);
+  if (ex?.slotId) {
+    const option = await exerciseOptionModel.ensureExists(
+      db, ex.slotId, newExerciseId, true, ex.restSeconds, ex.targetRepsMin, ex.targetRepsMax
+    );
+    await workoutExercise.updateExerciseOptionId(db, workoutExerciseId, option.id);
+    // Apply the option's stored settings to the current session row
+    await workoutExercise.updateRestSeconds(db, workoutExerciseId, option.restSeconds);
+    await workoutExercise.updateTargetReps(db, workoutExerciseId, option.targetRepsMin, option.targetRepsMax);
+  }
 }

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -2,7 +2,7 @@
 export const APP_CONFIG = {
   database: {
     name: 'vext.db',
-    schemaVersion: 8,
+    schemaVersion: 12,
   },
   defaults: {
     restSeconds: {

--- a/src/frontend/components/workout/ExerciseCard.tsx
+++ b/src/frontend/components/workout/ExerciseCard.tsx
@@ -1,10 +1,14 @@
-/** ExerciseCard - displays an exercise with its sets, rest timer, and rep goal controls. */
+/** ExerciseCard - displays an exercise with its sets, rest timer, rep goal, and alternative exercises. */
 import React, { useState, useEffect } from 'react';
-import { View, Text, TextInput, Pressable } from 'react-native';
+import { View, Text, TextInput, Pressable, Modal, ScrollView, ActivityIndicator } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { SetRow } from './SetRow';
 import { ConfirmDialog } from '@frontend/components/overlay/ConfirmDialog';
+import { ExercisePicker } from '@frontend/components/overlay/ExercisePicker';
+import { useExerciseAlternatives, useAddExerciseAlternative, useRemoveExerciseAlternative } from '@frontend/hooks/useWorkout';
+import { usePreviousSetsForExercises } from '@frontend/hooks/useHistory';
 import type { WorkoutExerciseFull, WorkoutSet } from '@shared/types/workout';
+import type { Exercise } from '@shared/types/exercise';
 
 function parseRepRange(input: string): { min: number | null; max: number | null } {
   const trimmed = input.trim();
@@ -30,6 +34,7 @@ function formatRepRange(min: number | null, max: number | null): string {
 type ExerciseCardProps = {
   exercise: WorkoutExerciseFull;
   isStrength: boolean;
+  seriesId?: string | null;
   previousSets?: WorkoutSet[];
   onMoveUp?: () => void;
   onMoveDown?: () => void;
@@ -41,11 +46,128 @@ type ExerciseCardProps = {
   onUpdateTargetReps: (min: number | null, max: number | null) => void;
   onStartRest?: () => void;
   onMakeSuperset?: () => void;
+  onSwitchToAlternative?: (workoutExerciseId: string, newExerciseId: string) => void;
 };
+
+function AlternativesModal({
+  onClose,
+  slotId,
+  seriesId,
+  exerciseName,
+  currentExerciseId,
+  onSwitch,
+}: {
+  onClose: () => void;
+  slotId: string;
+  seriesId: string | null | undefined;
+  exerciseName: string;
+  currentExerciseId: string;
+  onSwitch: (alternativeExerciseId: string) => void;
+}) {
+  const [showPicker, setShowPicker] = useState(false);
+  const { data: alternatives, isLoading } = useExerciseAlternatives(slotId);
+  const addAlternative = useAddExerciseAlternative(slotId);
+  const removeAlternative = useRemoveExerciseAlternative(slotId);
+
+  const alternativeIds = alternatives?.map((a) => a.alternativeExerciseId) ?? [];
+  const { data: lastSetsMap } = usePreviousSetsForExercises(alternativeIds, seriesId);
+
+  const handleSelectAlternative = (exercise: Exercise) => {
+    addAlternative.mutate(exercise.id);
+    setShowPicker(false);
+  };
+
+  return (
+    <>
+      <Modal visible transparent animationType="slide" onRequestClose={onClose}>
+        <View className="flex-1 justify-end">
+          <Pressable className="absolute inset-0 bg-black/60" onPress={onClose} />
+          <View className="rounded-t-2xl bg-background px-4 pt-4 pb-10" style={{ height: '65%' }}>
+            <View className="flex-row items-center justify-between mb-4">
+              <View className="flex-1">
+                <Text className="text-base font-bold text-foreground">Alternatives</Text>
+                <Text className="text-xs text-foreground-muted">{exerciseName}</Text>
+              </View>
+              <Pressable onPress={onClose} className="p-1">
+                <Ionicons name="close" size={22} color="rgb(163, 163, 163)" />
+              </Pressable>
+            </View>
+
+            {isLoading ? (
+              <View className="py-8 items-center">
+                <ActivityIndicator color="rgb(52, 211, 153)" />
+              </View>
+            ) : (
+              <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>
+                {alternatives?.length === 0 && (
+                  <View className="py-6 items-center">
+                    <Text className="text-sm text-foreground-muted">No alternatives set yet</Text>
+                    <Text className="text-xs text-foreground-subtle mt-1">Tap + to add an alternative exercise</Text>
+                  </View>
+                )}
+                {alternatives?.filter((alt) => alt.alternativeExerciseId !== currentExerciseId).map((alt) => {
+                  const lastSets = lastSetsMap?.get(alt.alternativeExerciseId);
+                  const firstSet = lastSets?.[0];
+                  const lastDone = firstSet
+                    ? firstSet.weightKg != null && firstSet.reps != null
+                      ? `Last: ${firstSet.weightKg} kg × ${firstSet.reps} reps`
+                      : firstSet.durationSeconds != null
+                        ? `Last: ${firstSet.durationSeconds}s`
+                        : null
+                    : null;
+
+                  return (
+                    <View key={alt.id} className="border-b border-background-100 py-3">
+                      <View className="flex-row items-center">
+                        <View className="flex-1">
+                          <Text className="text-sm font-medium text-foreground">{alt.alternativeName}</Text>
+                          {lastDone ? (
+                            <Text className="text-xs text-primary mt-0.5">{lastDone}</Text>
+                          ) : (
+                            <Text className="text-xs text-foreground-subtle mt-0.5">Never done in this series</Text>
+                          )}
+                        </View>
+                        <Pressable
+                          onPress={() => { onSwitch(alt.alternativeExerciseId); onClose(); }}
+                          className="rounded-lg bg-primary/15 px-3 py-1.5 mr-2"
+                        >
+                          <Text className="text-xs font-semibold text-primary">Switch</Text>
+                        </Pressable>
+                        <Pressable
+                          onPress={() => removeAlternative.mutate(alt.id)}
+                          className="p-1"
+                        >
+                          <Ionicons name="close-circle-outline" size={18} color="rgb(163, 163, 163)" />
+                        </Pressable>
+                      </View>
+                    </View>
+                  );
+                })}
+                <Pressable
+                  onPress={() => setShowPicker(true)}
+                  className="mt-3 rounded-xl border border-dashed border-background-100 py-3 items-center flex-row justify-center gap-1.5"
+                >
+                  <Ionicons name="add" size={18} color="rgb(52, 211, 153)" />
+                  <Text className="text-sm font-medium text-primary">Add Alternative</Text>
+                </Pressable>
+              </ScrollView>
+            )}
+          </View>
+        </View>
+      </Modal>
+      <ExercisePicker
+        visible={showPicker}
+        onSelect={handleSelectAlternative}
+        onClose={() => setShowPicker(false)}
+      />
+    </>
+  );
+}
 
 export const ExerciseCard = React.memo(function ExerciseCard({
   exercise,
   isStrength,
+  seriesId,
   previousSets,
   onMoveUp,
   onMoveDown,
@@ -57,6 +179,7 @@ export const ExerciseCard = React.memo(function ExerciseCard({
   onUpdateTargetReps,
   onStartRest,
   onMakeSuperset,
+  onSwitchToAlternative,
 }: ExerciseCardProps) {
   const [showRemoveConfirm, setShowRemoveConfirm] = useState(false);
   const [editingRest, setEditingRest] = useState(false);
@@ -65,6 +188,7 @@ export const ExerciseCard = React.memo(function ExerciseCard({
   const [localRestSeconds, setLocalRestSeconds] = useState(exercise.restSeconds);
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [hasAutoCollapsed, setHasAutoCollapsed] = useState(false);
+  const [showAlternatives, setShowAlternatives] = useState(false);
 
   useEffect(() => {
     setLocalRestSeconds(exercise.restSeconds);
@@ -98,176 +222,191 @@ export const ExerciseCard = React.memo(function ExerciseCard({
   };
 
   return (
-    <View className="mb-4 rounded-xl bg-background-50 p-4">
-      <View className="flex-row items-center justify-between mb-2">
-        <View className="flex-row items-center flex-1 gap-2">
-          {(onMoveUp || onMoveDown) && (
-            <View className="flex-row items-center gap-2">
-              <Pressable onPress={onMoveUp} disabled={!onMoveUp} className="p-1.5">
-                <Ionicons name="chevron-up" size={18} color={onMoveUp ? 'rgb(163, 163, 163)' : 'rgb(64, 64, 64)'} />
-              </Pressable>
-              <Pressable onPress={onMoveDown} disabled={!onMoveDown} className="p-1.5">
-                <Ionicons name="chevron-down" size={18} color={onMoveDown ? 'rgb(163, 163, 163)' : 'rgb(64, 64, 64)'} />
-              </Pressable>
-            </View>
-          )}
-          <Text className="text-base font-bold text-foreground flex-1">{exercise.exerciseName}</Text>
-        </View>
-        <Pressable onPress={() => setShowRemoveConfirm(true)} className="p-1">
-          <Ionicons name="close-circle-outline" size={20} color="rgb(163, 163, 163)" />
-        </Pressable>
-      </View>
-
-      {!isCollapsed && (
-        <>
-          {/* Badges row */}
-          <View className="flex-row items-center gap-2 mb-2 flex-wrap">
-            {/* Rest time badge */}
-            <Pressable
-              onPress={() => setEditingRest(!editingRest)}
-              className="flex-row items-center rounded-full bg-background-100 px-3 py-1"
-            >
-              <Ionicons name="timer-outline" size={14} color="rgb(163, 163, 163)" />
-              <Text className="ml-1 text-xs text-foreground-muted">
-                {localRestSeconds === 0 ? 'No rest' : `${localRestSeconds}s rest`}
-              </Text>
-            </Pressable>
-
-            {/* Rep goal badge */}
-            <Pressable
-              onPress={() => setEditingRepGoal(!editingRepGoal)}
-              className="flex-row items-center rounded-full bg-background-100 px-3 py-1"
-            >
-              <Ionicons name="fitness-outline" size={14} color="rgb(163, 163, 163)" />
-              <Text className="ml-1 text-xs text-foreground-muted">
-                {exercise.targetRepsMin != null && exercise.targetRepsMax != null
-                  ? `Goal: ${formatRepRange(exercise.targetRepsMin, exercise.targetRepsMax)} reps`
-                  : 'Rep goal'}
-              </Text>
-            </Pressable>
-
-            {/* Make Superset badge */}
-            {onMakeSuperset && (
-              <Pressable
-                onPress={onMakeSuperset}
-                className="flex-row items-center rounded-full bg-background-100 px-3 py-1"
-              >
-                <Ionicons name="layers-outline" size={14} color="rgb(163, 163, 163)" />
-                <Text className="ml-1 text-xs text-foreground-muted">Make Superset</Text>
-              </Pressable>
-            )}
-          </View>
-
-          {/* Rest time editor */}
-          {editingRest && (
-            <View className="flex-row items-center gap-2 mb-2">
-              <Pressable
-                onPress={() => handleUpdateRest(Math.max(0, localRestSeconds - 15))}
-                className="rounded-lg bg-background-100 px-3 py-1.5"
-              >
-                <Text className="text-sm text-foreground-muted">-15s</Text>
-              </Pressable>
-              <Text className="text-sm font-medium text-foreground min-w-[48px] text-center">
-                {localRestSeconds}s
-              </Text>
-              <Pressable
-                onPress={() => handleUpdateRest(localRestSeconds + 15)}
-                className="rounded-lg bg-background-100 px-3 py-1.5"
-              >
-                <Text className="text-sm text-foreground-muted">+15s</Text>
+    <>
+      <View className="mb-4 rounded-xl bg-background-50 overflow-hidden flex-row">
+        {/* Main content */}
+        <View className="flex-1">
+          <View className="p-4">
+            <View className="flex-row items-center justify-between mb-2">
+              <View className="flex-row items-center flex-1 gap-2">
+                {(onMoveUp || onMoveDown) && (
+                  <View className="flex-row items-center gap-2">
+                    <Pressable onPress={onMoveUp} disabled={!onMoveUp} className="p-1.5">
+                      <Ionicons name="chevron-up" size={18} color={onMoveUp ? 'rgb(163, 163, 163)' : 'rgb(64, 64, 64)'} />
+                    </Pressable>
+                    <Pressable onPress={onMoveDown} disabled={!onMoveDown} className="p-1.5">
+                      <Ionicons name="chevron-down" size={18} color={onMoveDown ? 'rgb(163, 163, 163)' : 'rgb(64, 64, 64)'} />
+                    </Pressable>
+                  </View>
+                )}
+                <Text className="text-base font-bold text-foreground flex-1">{exercise.exerciseName}</Text>
+              </View>
+              <Pressable onPress={() => setShowRemoveConfirm(true)} className="p-1">
+                <Ionicons name="close-circle-outline" size={20} color="rgb(163, 163, 163)" />
               </Pressable>
             </View>
-          )}
 
-          {/* Rep goal editor */}
-          {editingRepGoal && (
-            <View className="flex-row items-center gap-2 mb-2">
-              <TextInput
-                className="w-24 rounded-lg bg-background-100 px-3 py-2 text-center text-sm text-foreground"
-                placeholder="8-12"
-                placeholderTextColor="rgb(115, 115, 115)"
-                keyboardType="number-pad"
-                value={repGoalInput}
-                onChangeText={setRepGoalInput}
-                onSubmitEditing={handleSaveRepGoal}
-              />
-              <Pressable onPress={handleSaveRepGoal} className="rounded-lg bg-primary px-3 py-1.5">
-                <Text className="text-sm font-medium text-background">Save</Text>
-              </Pressable>
-              {exercise.targetRepsMin != null && (
+            {!isCollapsed && (
+              <>
+                {/* Badges row */}
+                <View className="flex-row items-center gap-2 mb-2 flex-wrap">
+                  <Pressable
+                    onPress={() => setEditingRest(!editingRest)}
+                    className="flex-row items-center rounded-full bg-background-100 px-3 py-1"
+                  >
+                    <Ionicons name="timer-outline" size={14} color="rgb(163, 163, 163)" />
+                    <Text className="ml-1 text-xs text-foreground-muted">
+                      {localRestSeconds === 0 ? 'No rest' : `${localRestSeconds}s rest`}
+                    </Text>
+                  </Pressable>
+
+                  <Pressable
+                    onPress={() => setEditingRepGoal(!editingRepGoal)}
+                    className="flex-row items-center rounded-full bg-background-100 px-3 py-1"
+                  >
+                    <Ionicons name="fitness-outline" size={14} color="rgb(163, 163, 163)" />
+                    <Text className="ml-1 text-xs text-foreground-muted">
+                      {exercise.targetRepsMin != null && exercise.targetRepsMax != null
+                        ? `Goal: ${formatRepRange(exercise.targetRepsMin, exercise.targetRepsMax)} reps`
+                        : 'Rep goal'}
+                    </Text>
+                  </Pressable>
+
+                  {onMakeSuperset && (
+                    <Pressable
+                      onPress={onMakeSuperset}
+                      className="flex-row items-center rounded-full bg-background-100 px-3 py-1"
+                    >
+                      <Ionicons name="layers-outline" size={14} color="rgb(163, 163, 163)" />
+                      <Text className="ml-1 text-xs text-foreground-muted">Make Superset</Text>
+                    </Pressable>
+                  )}
+                </View>
+
+                {/* Rest time editor */}
+                {editingRest && (
+                  <View className="flex-row items-center gap-2 mb-2">
+                    <Pressable
+                      onPress={() => handleUpdateRest(Math.max(0, localRestSeconds - 15))}
+                      className="rounded-lg bg-background-100 px-3 py-1.5"
+                    >
+                      <Text className="text-sm text-foreground-muted">-15s</Text>
+                    </Pressable>
+                    <Text className="text-sm font-medium text-foreground min-w-[48px] text-center">
+                      {localRestSeconds}s
+                    </Text>
+                    <Pressable
+                      onPress={() => handleUpdateRest(localRestSeconds + 15)}
+                      className="rounded-lg bg-background-100 px-3 py-1.5"
+                    >
+                      <Text className="text-sm text-foreground-muted">+15s</Text>
+                    </Pressable>
+                  </View>
+                )}
+
+                {/* Rep goal editor */}
+                {editingRepGoal && (
+                  <View className="flex-row items-center gap-2 mb-2">
+                    <TextInput
+                      className="w-24 rounded-lg bg-background-100 px-3 py-2 text-center text-sm text-foreground"
+                      placeholder="8-12"
+                      placeholderTextColor="rgb(115, 115, 115)"
+                      keyboardType="number-pad"
+                      value={repGoalInput}
+                      onChangeText={setRepGoalInput}
+                      onSubmitEditing={handleSaveRepGoal}
+                    />
+                    <Pressable onPress={handleSaveRepGoal} className="rounded-lg bg-primary px-3 py-1.5">
+                      <Text className="text-sm font-medium text-background">Save</Text>
+                    </Pressable>
+                    {exercise.targetRepsMin != null && (
+                      <Pressable
+                        onPress={() => {
+                          onUpdateTargetReps(null, null);
+                          setRepGoalInput('');
+                          setEditingRepGoal(false);
+                        }}
+                        className="rounded-lg bg-background-100 px-3 py-1.5"
+                      >
+                        <Text className="text-xs text-foreground-muted">Clear</Text>
+                      </Pressable>
+                    )}
+                  </View>
+                )}
+
+                {/* Header row */}
+                <View className="flex-row items-center py-1 gap-2 mb-1">
+                  <View className="w-8" />
+                  {isStrength ? (
+                    <>
+                      <Text className="flex-1 text-center text-xs text-foreground-subtle">Weight</Text>
+                      <Text className="text-xs text-foreground-subtle" />
+                      <Text className="flex-1 text-center text-xs text-foreground-subtle">Reps</Text>
+                    </>
+                  ) : (
+                    <>
+                      <Text className="flex-1 text-center text-xs text-foreground-subtle">Duration</Text>
+                      <Text className="flex-1 text-center text-xs text-foreground-subtle">Distance</Text>
+                    </>
+                  )}
+                  <View className="w-10" />
+                  <View className="w-8" />
+                </View>
+
+                {/* Existing sets */}
+                {exercise.sets.map((set, index) => (
+                  <SetRow
+                    key={set.id}
+                    set={set}
+                    previousSet={previousSets?.[index]}
+                    setNumber={set.setNumber}
+                    isStrength={isStrength}
+                    targetRepsMin={exercise.targetRepsMin}
+                    targetRepsMax={exercise.targetRepsMax}
+                    restSeconds={exercise.restSeconds}
+                    onSave={(data) => onSaveSet(set.id, data)}
+                    onStartRest={onStartRest}
+                    onRemove={() => onRemoveSet(set.id)}
+                  />
+                ))}
+
+                {/* Add Set button */}
                 <Pressable
-                  onPress={() => {
-                    onUpdateTargetReps(null, null);
-                    setRepGoalInput('');
-                    setEditingRepGoal(false);
-                  }}
-                  className="rounded-lg bg-background-100 px-3 py-1.5"
+                  onPress={onAddSet}
+                  className="mt-2 rounded-xl border border-dashed border-background-100 py-3 items-center"
                 >
-                  <Text className="text-xs text-foreground-muted">Clear</Text>
+                  <View className="flex-row items-center gap-1.5">
+                    <Ionicons name="add" size={18} color="rgb(52, 211, 153)" />
+                    <Text className="text-sm font-medium text-primary">Add Set</Text>
+                  </View>
                 </Pressable>
-              )}
-            </View>
-          )}
-
-          {/* Header row */}
-          <View className="flex-row items-center py-1 gap-2 mb-1">
-            <View className="w-8" />
-            {isStrength ? (
-              <>
-                <Text className="flex-1 text-center text-xs text-foreground-subtle">Weight</Text>
-                <Text className="text-xs text-foreground-subtle" />
-                <Text className="flex-1 text-center text-xs text-foreground-subtle">Reps</Text>
-              </>
-            ) : (
-              <>
-                <Text className="flex-1 text-center text-xs text-foreground-subtle">Duration</Text>
-                <Text className="flex-1 text-center text-xs text-foreground-subtle">Distance</Text>
               </>
             )}
-            <View className="w-10" />
-            <View className="w-8" />
           </View>
 
-          {/* Existing sets */}
-          {exercise.sets.map((set, index) => (
-            <SetRow
-              key={set.id}
-              set={set}
-              previousSet={previousSets?.[index]}
-              setNumber={set.setNumber}
-              isStrength={isStrength}
-              targetRepsMin={exercise.targetRepsMin}
-              targetRepsMax={exercise.targetRepsMax}
-              restSeconds={exercise.restSeconds}
-              onSave={(data) => onSaveSet(set.id, data)}
-              onStartRest={onStartRest}
-              onRemove={() => onRemoveSet(set.id)}
-            />
-          ))}
-
-          {/* Add Set button */}
+          {/* Collapse toggle */}
           <Pressable
-            onPress={onAddSet}
-            className="mt-2 rounded-xl border border-dashed border-background-100 py-3 items-center"
+            onPress={() => setIsCollapsed((c) => !c)}
+            className="border-t border-background-100 py-2 items-center"
           >
-            <View className="flex-row items-center gap-1.5">
-              <Ionicons name="add" size={18} color="rgb(52, 211, 153)" />
-              <Text className="text-sm font-medium text-primary">Add Set</Text>
-            </View>
+            <Ionicons
+              name={isCollapsed ? 'chevron-down' : 'chevron-up'}
+              size={16}
+              color="rgb(115, 115, 115)"
+            />
           </Pressable>
-        </>
-      )}
+        </View>
 
-      <Pressable
-        onPress={() => setIsCollapsed((c) => !c)}
-        className="mt-3 -mx-4 -mb-4 rounded-b-xl border-t border-background-100 py-2 items-center"
-      >
-        <Ionicons
-          name={isCollapsed ? 'chevron-down' : 'chevron-up'}
-          size={16}
-          color="rgb(115, 115, 115)"
-        />
-      </Pressable>
+        {/* Alternatives side bar */}
+        {seriesId && (
+          <Pressable
+            onPress={() => setShowAlternatives(true)}
+            className="w-10 items-center justify-center border-l border-background-100 bg-background-100/30"
+          >
+            <Ionicons name="swap-horizontal-outline" size={18} color="rgb(115, 115, 115)" />
+          </Pressable>
+        )}
+      </View>
 
       <ConfirmDialog
         visible={showRemoveConfirm}
@@ -281,6 +420,17 @@ export const ExerciseCard = React.memo(function ExerciseCard({
         }}
         onCancel={() => setShowRemoveConfirm(false)}
       />
-    </View>
+
+      {showAlternatives && (
+        <AlternativesModal
+          onClose={() => setShowAlternatives(false)}
+          slotId={exercise.slotId}
+          seriesId={seriesId}
+          exerciseName={exercise.exerciseName}
+          currentExerciseId={exercise.exerciseId}
+          onSwitch={(altId) => onSwitchToAlternative?.(exercise.id, altId)}
+        />
+      )}
+    </>
   );
 });

--- a/src/frontend/hooks/useHistory.ts
+++ b/src/frontend/hooks/useHistory.ts
@@ -62,3 +62,17 @@ export function usePreviousSetsForExercises(exerciseIds: string[], seriesId?: st
     staleTime: 5 * 60 * 1000,
   });
 }
+
+export function useWorkoutsByMonth(year: number, month: number) {
+  const db = useDatabase();
+  // month is 1-indexed
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const startDate = `${year}-${pad(month)}-01T00:00:00`;
+  const lastDay = new Date(year, month, 0).getDate();
+  const endDate = `${year}-${pad(month)}-${pad(lastDay)}T23:59:59`;
+  return useQuery({
+    queryKey: ['workoutsByMonth', year, month],
+    queryFn: () => workoutService.getWorkoutSummariesByDateRange(db, startDate, endDate),
+    staleTime: 60 * 1000,
+  });
+}

--- a/src/frontend/hooks/useWorkout.ts
+++ b/src/frontend/hooks/useWorkout.ts
@@ -4,6 +4,7 @@ import * as workoutService from '@backend/services/workoutService';
 import { useDatabase } from '@frontend/hooks/useDatabase';
 import type { WorkoutSetInput } from '@backend/models/workoutSet';
 import type { WorkoutFull } from '@shared/types/workout';
+import type { ExerciseAlternative } from '@backend/models/exerciseAlternative';
 
 export function useActiveWorkout() {
   const db = useDatabase();
@@ -133,6 +134,7 @@ export function useCompleteWorkout() {
       queryClient.invalidateQueries({ queryKey: ['activeWorkout'] });
       queryClient.invalidateQueries({ queryKey: ['workoutHistory'] });
       queryClient.invalidateQueries({ queryKey: ['workoutGroupDetails'] });
+      queryClient.invalidateQueries({ queryKey: ['previousSets'] });
       queryClient.invalidateQueries({ queryKey: ['todayStats'] });
       queryClient.invalidateQueries({ queryKey: ['weeklyStats'] });
       queryClient.invalidateQueries({ queryKey: ['currentStreak'] });
@@ -176,6 +178,7 @@ export function useDeleteWorkout() {
       queryClient.invalidateQueries({ queryKey: ['workoutHistory'] });
       queryClient.invalidateQueries({ queryKey: ['workoutHistoryCount'] });
       queryClient.invalidateQueries({ queryKey: ['workoutGroupDetails'] });
+      queryClient.invalidateQueries({ queryKey: ['previousSets'] });
       queryClient.invalidateQueries({ queryKey: ['todayStats'] });
       queryClient.invalidateQueries({ queryKey: ['weeklyStats'] });
       queryClient.invalidateQueries({ queryKey: ['currentStreak'] });
@@ -193,6 +196,7 @@ export function useDeleteWorkouts() {
       queryClient.invalidateQueries({ queryKey: ['workoutHistory'] });
       queryClient.invalidateQueries({ queryKey: ['workoutHistoryCount'] });
       queryClient.invalidateQueries({ queryKey: ['workoutGroupDetails'] });
+      queryClient.invalidateQueries({ queryKey: ['previousSets'] });
       queryClient.invalidateQueries({ queryKey: ['todayStats'] });
       queryClient.invalidateQueries({ queryKey: ['weeklyStats'] });
       queryClient.invalidateQueries({ queryKey: ['currentStreak'] });
@@ -327,6 +331,74 @@ export function useUpdateWorkoutName() {
       queryClient.invalidateQueries({ queryKey: ['workoutHistory'] });
       queryClient.invalidateQueries({ queryKey: ['workoutGroupDetails'] });
       queryClient.invalidateQueries({ queryKey: ['recentWorkouts'] });
+    },
+  });
+}
+
+export function useMoveSeriesUp() {
+  const db = useDatabase();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (seriesId: string) => workoutService.moveSeriesUp(db, seriesId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['workoutHistory'] });
+    },
+  });
+}
+
+export function useMoveSeriesDown() {
+  const db = useDatabase();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (seriesId: string) => workoutService.moveSeriesDown(db, seriesId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['workoutHistory'] });
+    },
+  });
+}
+
+export function useExerciseAlternatives(slotId: string | null | undefined) {
+  const db = useDatabase();
+  return useQuery<ExerciseAlternative[]>({
+    queryKey: ['exerciseAlternatives', slotId ?? 'none'],
+    queryFn: () => workoutService.getExerciseAlternatives(db, slotId!),
+    enabled: !!slotId,
+    staleTime: 60 * 1000,
+  });
+}
+
+export function useAddExerciseAlternative(slotId: string | null | undefined) {
+  const db = useDatabase();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (alternativeExerciseId: string) =>
+      workoutService.addExerciseAlternative(db, slotId!, alternativeExerciseId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['exerciseAlternatives', slotId ?? 'none'] });
+    },
+  });
+}
+
+export function useRemoveExerciseAlternative(slotId: string | null | undefined) {
+  const db = useDatabase();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (alternativeId: string) => workoutService.removeExerciseAlternative(db, alternativeId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['exerciseAlternatives', slotId ?? 'none'] });
+    },
+  });
+}
+
+export function useSwitchWorkoutExercise(workoutId: string) {
+  const db = useDatabase();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ workoutExerciseId, newExerciseId }: { workoutExerciseId: string; newExerciseId: string }) =>
+      workoutService.switchWorkoutExercise(db, workoutExerciseId, newExerciseId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['workout', workoutId] });
+      queryClient.invalidateQueries({ queryKey: ['previousSets'] });
     },
   });
 }

--- a/src/frontend/navigation/TabBar.tsx
+++ b/src/frontend/navigation/TabBar.tsx
@@ -9,6 +9,7 @@ import type { BottomTabBarProps } from '@react-navigation/bottom-tabs';
 const TAB_ICONS: Record<string, { active: keyof typeof Ionicons.glyphMap; inactive: keyof typeof Ionicons.glyphMap }> = {
   index: { active: 'home', inactive: 'home-outline' },
   workouts: { active: 'time', inactive: 'time-outline' },
+  calendar: { active: 'calendar', inactive: 'calendar-outline' },
   exercises: { active: 'barbell', inactive: 'barbell-outline' },
   profile: { active: 'person', inactive: 'person-outline' },
 };

--- a/src/shared/types/workout.ts
+++ b/src/shared/types/workout.ts
@@ -23,6 +23,7 @@ export interface WorkoutType {
 export interface WorkoutSeries {
   id: string;
   name: string;
+  sortOrder: number;
   createdAt: string;
 }
 
@@ -40,6 +41,24 @@ export interface Workout {
   lastStartedAt: string | null;
 }
 
+export interface ExerciseSlot {
+  id: string;
+  seriesId: string;
+  sortOrder: number;
+  createdAt: string;
+}
+
+export interface ExerciseOption {
+  id: string;
+  slotId: string;
+  exerciseId: string;
+  isPrimary: boolean;
+  restSeconds: number;
+  targetRepsMin: number | null;
+  targetRepsMax: number | null;
+  createdAt: string;
+}
+
 export interface SupersetGroup {
   id: string;
   workoutId: string;
@@ -51,6 +70,8 @@ export interface WorkoutExercise {
   id: string;
   workoutId: string;
   exerciseId: string;
+  slotId: string;
+  exerciseOptionId: string | null;
   sortOrder: number;
   restSeconds: number;
   targetRepsMin: number | null;
@@ -90,6 +111,7 @@ export interface WorkoutExerciseFull extends WorkoutExercise {
 /** Summary for history list items */
 export interface WorkoutSummary {
   id: string;
+  seriesId: string | null;
   name: string | null;
   workoutTypeName: string;
   status: WorkoutStatus;
@@ -105,6 +127,7 @@ export interface WorkoutSummary {
 /** Grouped repeated workouts for history list */
 export interface WorkoutGroup {
   key: string;
+  seriesId: string | null;
   displayName: string;
   workoutTypeName: string;
   latest: WorkoutSummary;


### PR DESCRIPTION
## Summary

- **Schema v11→v12**: introduces `exercise_slots` and `exercise_options` as first-class tables, separating template-level exercise definitions from session-level records. Backfills slots/options from existing `workout_exercises` and `exercise_slot_alternatives`.
- **Fix**: switching to an alternative exercise now applies that alternative's stored rep/rest goals to the session row (previously only `exercise_id` was swapped).
- **Fix**: current exercise is hidden from its own alternatives modal.

## Test plan

- [ ] Fresh install: migration runs on empty DB, tables created with no errors
- [ ] Existing data: migration backfills `exercise_slots` + `exercise_options` from existing `workout_exercises`
- [ ] Add exercise: new slot + option created, `exercise_option_id` set on `workout_exercise`
- [ ] Repeat workout: slot and option reused, `exercise_option_id` populated
- [ ] Switch exercise via alternatives: rep/rest goals update to match the alternative's stored settings
- [ ] Current exercise does not appear in its own alternatives list
- [ ] Update rest/reps: propagated to `exercise_option`
- [ ] All existing functionality (sets, supersets, stats, history) works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)