### PR TITLE
Exercise notes, last-weight fix, profile polish (v1.5.0)

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "Vext Dev",
     "slug": "vext",
     "scheme": "vext",
-    "version": "1.0.0",
+    "version": "1.5.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -2,6 +2,8 @@
 import React, { useState, useEffect } from 'react';
 import { View, Text, TextInput, Switch, Pressable, ScrollView } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import Constants from 'expo-constants';
+import * as Linking from 'expo-linking';
 import { useSettingsStore } from '@backend/store/settingsStore';
 import { useDatabase } from '@frontend/hooks/useDatabase';
 import { useBodyWeightHistory, useLogBodyWeight, useDeleteBodyWeight } from '@frontend/hooks/useBodyWeight';
@@ -10,6 +12,9 @@ import { SelectPicker } from '@frontend/components/overlay/SelectPicker';
 import { ConfirmDialog } from '@frontend/components/overlay/ConfirmDialog';
 import { formatWeight } from '@shared/utils/formatting';
 import type { UnitSystem } from '@shared/types/settings';
+
+const RELEASES_URL = 'https://github.com/leonx03/vext/releases';
+const APP_VERSION = Constants.expoConfig?.version ?? '?';
 
 const REST_OPTIONS = [
   { label: '30 seconds', value: '30' },
@@ -181,21 +186,15 @@ export default function ProfileScreen() {
           <Text className="text-sm font-medium text-foreground-muted mb-3">About</Text>
           <View className="flex-row items-center justify-between">
             <Text className="text-base text-foreground">Vext</Text>
-            <Text className="text-sm text-foreground-subtle">v1.0.0</Text>
+            <Text className="text-sm text-foreground-subtle">v{APP_VERSION}</Text>
           </View>
-        </View>
-
-        {/* Coming soon */}
-        <View className="mx-4 mt-3 rounded-xl bg-background-50 p-4">
-          <Text className="text-sm font-medium text-foreground-muted mb-3">Coming Soon</Text>
-          {['Data Export', 'Custom Exercises', 'Theme Customization'].map((feature) => (
-            <View key={feature} className="flex-row items-center justify-between py-2">
-              <Text className="text-base text-foreground-subtle">{feature}</Text>
-              <View className="rounded-full bg-background-100 px-2 py-0.5">
-                <Text className="text-xs text-foreground-subtle">Soon</Text>
-              </View>
-            </View>
-          ))}
+          <Pressable
+            onPress={() => Linking.openURL(RELEASES_URL)}
+            className="mt-3 flex-row items-center justify-center gap-2 rounded-lg bg-background-100 py-3"
+          >
+            <Ionicons name="cloud-download-outline" size={18} color="rgb(52, 211, 153)" />
+            <Text className="text-sm font-semibold text-primary">Check for Updates</Text>
+          </Pressable>
         </View>
       </ScrollView>
 

--- a/app/workout/[id].tsx
+++ b/app/workout/[id].tsx
@@ -29,6 +29,7 @@ import {
   useUpdateSupersetRestSeconds,
   useLogSupersetRound,
   useSwitchWorkoutExercise,
+  useSetWorkoutExerciseNote,
 } from '@frontend/hooks/useWorkout';
 import { usePreviousSetsForExercises } from '@frontend/hooks/useHistory';
 import { ExerciseCategory } from '@shared/types/exercise';
@@ -77,6 +78,7 @@ function ActiveWorkoutContent({ workout, id }: { workout: WorkoutFull; id: strin
   const updateRestSeconds = useUpdateWorkoutExerciseRestSeconds(id);
   const updateTargetReps = useUpdateExerciseTargetReps(id);
   const switchExercise = useSwitchWorkoutExercise(id);
+  const setExerciseNote = useSetWorkoutExerciseNote(id);
   const makeSuperset = useMakeSuperset(id);
   const addToSuperset = useAddExerciseToSuperset(id);
   const disbandSuperset = useDisbandSuperset(id);
@@ -201,6 +203,9 @@ function ActiveWorkoutContent({ workout, id }: { workout: WorkoutFull; id: strin
                   onMakeSuperset={() =>
                     setPickerMode({ type: 'makeSuperset', workoutExerciseId: ex.id })
                   }
+                  onSaveNote={(text) =>
+                    setExerciseNote.mutate({ workoutExerciseId: ex.id, notes: text })
+                  }
                   onSwitchToAlternative={(workoutExerciseId, newExerciseId) =>
                     switchExercise.mutate({ workoutExerciseId, newExerciseId })
                   }
@@ -238,6 +243,9 @@ function ActiveWorkoutContent({ workout, id }: { workout: WorkoutFull; id: strin
                 seriesId={workout.seriesId}
                 onSwitchToAlternative={(workoutExerciseId, newExerciseId) =>
                   switchExercise.mutate({ workoutExerciseId, newExerciseId })
+                }
+                onSaveNote={(workoutExerciseId, text) =>
+                  setExerciseNote.mutate({ workoutExerciseId, notes: text })
                 }
               />
             );

--- a/src/backend/database/migrations.ts
+++ b/src/backend/database/migrations.ts
@@ -397,6 +397,48 @@ const migrations: Migration[] = [
       CREATE INDEX idx_scheduled_workouts_series ON scheduled_workouts(series_id);
     `);
   },
+  // v15 → v16: Per-workout-exercise notes, scoped per alternative (exercise_option).
+  // Keyed by (workout_exercise_id, exercise_option_id) so switching the active
+  // alternative on a slot swaps which note is shown without losing the others.
+  async (db) => {
+    await db.execAsync(`
+      CREATE TABLE workout_exercise_notes (
+        id TEXT PRIMARY KEY NOT NULL,
+        workout_exercise_id TEXT NOT NULL REFERENCES workout_exercises(id) ON DELETE CASCADE,
+        exercise_option_id TEXT,
+        notes TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      CREATE UNIQUE INDEX idx_wen_we_option ON workout_exercise_notes(workout_exercise_id, exercise_option_id);
+      CREATE INDEX idx_wen_we ON workout_exercise_notes(workout_exercise_id);
+    `);
+  },
+  // v16 → v17: Move exercise notes from per-workout to per-series. Notes now key on
+  // exercise_option (slot + exercise within a series), so they're shared across every
+  // workout in the series and stay unique per alternative. Migrates any existing notes.
+  async (db) => {
+    await db.execAsync(`
+      CREATE TABLE exercise_option_notes (
+        exercise_option_id TEXT PRIMARY KEY NOT NULL REFERENCES exercise_options(id) ON DELETE CASCADE,
+        notes TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `);
+    // Carry over the most recently-updated note per option from the old per-workout table.
+    await db.execAsync(`
+      INSERT OR IGNORE INTO exercise_option_notes (exercise_option_id, notes, created_at, updated_at)
+      SELECT wen.exercise_option_id, wen.notes, wen.created_at, wen.updated_at
+      FROM workout_exercise_notes wen
+      WHERE wen.exercise_option_id IS NOT NULL
+        AND wen.updated_at = (
+          SELECT MAX(w2.updated_at) FROM workout_exercise_notes w2
+          WHERE w2.exercise_option_id = wen.exercise_option_id
+        );
+    `);
+    await db.execAsync(`DROP TABLE workout_exercise_notes;`);
+  },
 ];
 
 export async function runMigrations(db: SQLite.SQLiteDatabase): Promise<void> {

--- a/src/backend/models/exerciseOptionNote.ts
+++ b/src/backend/models/exerciseOptionNote.ts
@@ -1,0 +1,32 @@
+/** ExerciseOptionNote model - notes attached to an exercise option (per-series, per-alternative). */
+import type * as SQLite from 'expo-sqlite';
+
+/**
+ * Sets (upserts) the note for an exercise option. Because an option is shared by
+ * every workout in its series, the note shows on each session of that series and
+ * stays unique per alternative. An empty/whitespace-only note deletes the row.
+ */
+export async function setNote(
+  db: SQLite.SQLiteDatabase,
+  exerciseOptionId: string,
+  notes: string
+): Promise<void> {
+  const trimmed = notes.trim();
+
+  if (!trimmed) {
+    await db.runAsync(
+      `DELETE FROM exercise_option_notes WHERE exercise_option_id = ?`,
+      exerciseOptionId
+    );
+    return;
+  }
+
+  await db.runAsync(
+    `INSERT INTO exercise_option_notes (exercise_option_id, notes)
+     VALUES (?, ?)
+     ON CONFLICT(exercise_option_id)
+     DO UPDATE SET notes = excluded.notes, updated_at = datetime('now')`,
+    exerciseOptionId,
+    trimmed
+  );
+}

--- a/src/backend/models/workoutExercise.ts
+++ b/src/backend/models/workoutExercise.ts
@@ -25,6 +25,7 @@ interface WorkoutExerciseRow {
 interface WorkoutExerciseFullRow extends WorkoutExerciseRow {
   exercise_name: string;
   exercise_category: string;
+  note_text: string | null;
 }
 
 function mapRow(row: WorkoutExerciseRow): WorkoutExercise {
@@ -50,9 +51,16 @@ function mapFullRow(row: WorkoutExerciseFullRow): WorkoutExerciseFull {
     ...mapRow(row),
     exerciseName: row.exercise_name,
     exerciseCategory: row.exercise_category,
+    note: row.note_text ?? null,
     sets: [],
   };
 }
+
+// Joins the note for the currently-selected exercise option. Notes live on the
+// option (series + slot + exercise), so they're shared across every workout in the
+// series and stay unique per alternative.
+const NOTE_JOIN = `LEFT JOIN exercise_option_notes eon
+       ON eon.exercise_option_id = we.exercise_option_id`;
 
 export async function addToWorkout(
   db: SQLite.SQLiteDatabase,
@@ -100,9 +108,11 @@ export async function getByWorkout(
     `SELECT
        we.*,
        e.name  AS exercise_name,
-       e.category AS exercise_category
+       e.category AS exercise_category,
+       eon.notes AS note_text
      FROM workout_exercises we
      JOIN exercises e ON e.id = we.exercise_id
+     ${NOTE_JOIN}
      WHERE we.workout_id = ?
      ORDER BY we.sort_order`,
     workoutId
@@ -219,9 +229,11 @@ export async function getBySuperset(
     `SELECT
        we.*,
        e.name AS exercise_name,
-       e.category AS exercise_category
+       e.category AS exercise_category,
+       eon.notes AS note_text
      FROM workout_exercises we
      JOIN exercises e ON e.id = we.exercise_id
+     ${NOTE_JOIN}
      WHERE we.superset_group_id = ?
      ORDER BY we.superset_position`,
     groupId

--- a/src/backend/models/workoutSet.ts
+++ b/src/backend/models/workoutSet.ts
@@ -158,8 +158,11 @@ export async function getByWorkout(
 
 /**
  * Returns all sets from the most recent completed workout containing the given exercise
- * within the same series. If seriesId is null/undefined (standalone workout), returns empty.
- * Used to show "Last time" reference data on ExerciseCard.
+ * within the same series, skipping workouts where the exercise was logged with no recorded
+ * value (no weight/duration/distance). This way the "Last time" reference always reflects
+ * the last session where something was actually entered — leaving an exercise blank one
+ * session falls back to the session before it rather than showing 0.
+ * If seriesId is null/undefined (standalone workout), returns empty.
  */
 export async function getLatestSetsForExercise(
   db: SQLite.SQLiteDatabase,
@@ -169,24 +172,31 @@ export async function getLatestSetsForExercise(
   // New standalone workouts (no series) should show no reference weights
   if (!seriesId) return [];
 
-  const rows = await db.getAllAsync<WorkoutSetRow>(
-    `SELECT ws.*
-     FROM workout_sets ws
-     JOIN workout_exercises we ON we.id = ws.workout_exercise_id
+  // Pick the most recent completed workout-exercise that has at least one recorded set.
+  const latest = await db.getFirstAsync<{ workout_exercise_id: string }>(
+    `SELECT we.id AS workout_exercise_id
+     FROM workout_exercises we
      JOIN workouts w ON w.id = we.workout_id
      WHERE we.exercise_id = ?
        AND w.status = 'completed'
        AND w.series_id = ?
-     ORDER BY w.completed_at DESC, ws.set_number ASC`,
+       AND EXISTS (
+         SELECT 1 FROM workout_sets ws
+         WHERE ws.workout_exercise_id = we.id
+           AND (ws.weight_kg IS NOT NULL OR ws.duration_seconds IS NOT NULL OR ws.distance_meters IS NOT NULL)
+       )
+     ORDER BY w.completed_at DESC
+     LIMIT 1`,
     exerciseId,
     seriesId
   );
-  if (rows.length === 0) return [];
-  // All rows are ordered by completed_at DESC — take only sets from the most recent workout
-  const firstWorkoutExerciseId = rows[0].workout_exercise_id;
-  return rows
-    .filter((r) => r.workout_exercise_id === firstWorkoutExerciseId)
-    .map(mapRow);
+  if (!latest) return [];
+
+  const rows = await db.getAllAsync<WorkoutSetRow>(
+    `SELECT * FROM workout_sets WHERE workout_exercise_id = ? ORDER BY set_number ASC`,
+    latest.workout_exercise_id
+  );
+  return rows.map(mapRow);
 }
 
 /**

--- a/src/backend/services/workoutService.ts
+++ b/src/backend/services/workoutService.ts
@@ -11,6 +11,7 @@ import * as workoutSeriesModel from '@backend/models/workoutSeries';
 import * as exerciseSlotModel from '@backend/models/exerciseSlot';
 import * as exerciseOptionModel from '@backend/models/exerciseOption';
 import * as exerciseAlternativeModel from '@backend/models/exerciseAlternative';
+import * as exerciseOptionNoteModel from '@backend/models/exerciseOptionNote';
 import type { ExerciseAlternative } from '@backend/models/exerciseAlternative';
 import { getDefaultRestSeconds } from '@backend/services/timerService';
 import { APP_CONFIG } from '@config/app';
@@ -645,4 +646,23 @@ export async function switchWorkoutExercise(
     await workoutExercise.updateRestSeconds(db, workoutExerciseId, option.restSeconds);
     await workoutExercise.updateTargetReps(db, workoutExerciseId, option.targetRepsMin, option.targetRepsMax);
   }
+}
+
+/**
+ * Sets the note for an exercise, scoped to its currently-selected alternative.
+ * Notes live on the exercise option, so they're shared across every workout in the
+ * series and stay unique per alternative. An empty string clears the note. The
+ * option is resolved from the workout exercise so callers only need its id.
+ */
+export async function setWorkoutExerciseNote(
+  db: SQLite.SQLiteDatabase,
+  workoutExerciseId: string,
+  notes: string
+): Promise<void> {
+  const ex = await workoutExercise.getById(db, workoutExerciseId);
+  if (!ex) throw new Error(`Workout exercise not found, id ${workoutExerciseId}`);
+  // No option means a standalone workout with no series — nowhere series-level to
+  // store the note. In practice every workout has a series, so this is defensive.
+  if (!ex.exerciseOptionId) return;
+  await exerciseOptionNoteModel.setNote(db, ex.exerciseOptionId, notes);
 }

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -2,7 +2,7 @@
 export const APP_CONFIG = {
   database: {
     name: 'vext.db',
-    schemaVersion: 15,
+    schemaVersion: 17,
   },
   defaults: {
     restSeconds: {

--- a/src/frontend/components/workout/ExerciseCard.tsx
+++ b/src/frontend/components/workout/ExerciseCard.tsx
@@ -33,6 +33,7 @@ type ExerciseCardProps = {
   isStrength: boolean;
   seriesId?: string | null;
   previousSets?: WorkoutSet[];
+  onSaveNote?: (text: string) => void;
   onMoveUp?: () => void;
   onMoveDown?: () => void;
   onAddSet: () => void;
@@ -51,6 +52,7 @@ export const ExerciseCard = React.memo(function ExerciseCard({
   isStrength,
   seriesId,
   previousSets,
+  onSaveNote,
   onMoveUp,
   onMoveDown,
   onAddSet,
@@ -71,10 +73,17 @@ export const ExerciseCard = React.memo(function ExerciseCard({
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [hasAutoCollapsed, setHasAutoCollapsed] = useState(false);
   const [showAlternatives, setShowAlternatives] = useState(false);
+  const [editingNote, setEditingNote] = useState(false);
+  const [noteInput, setNoteInput] = useState(exercise.note ?? '');
 
   useEffect(() => {
     setLocalRestSeconds(exercise.restSeconds);
   }, [exercise.restSeconds]);
+
+  // Resync when the note changes underneath us (e.g. switching alternative)
+  useEffect(() => {
+    setNoteInput(exercise.note ?? '');
+  }, [exercise.note]);
 
   useEffect(() => {
     setRepGoalInput(formatRepRange(exercise.targetRepsMin, exercise.targetRepsMax));
@@ -101,6 +110,13 @@ export const ExerciseCard = React.memo(function ExerciseCard({
     const { min, max } = parseRepRange(repGoalInput);
     onUpdateTargetReps(min, max);
     setEditingRepGoal(false);
+  };
+
+  const handleSaveNote = () => {
+    if ((noteInput.trim() || '') !== (exercise.note ?? '')) {
+      onSaveNote?.(noteInput);
+    }
+    setEditingNote(false);
   };
 
   return (
@@ -154,6 +170,18 @@ export const ExerciseCard = React.memo(function ExerciseCard({
                     </Text>
                   </Pressable>
 
+                  {onSaveNote && (
+                    <Pressable
+                      onPress={() => setEditingNote((e) => !e)}
+                      className="flex-row items-center rounded-full bg-background-100 px-3 py-1"
+                    >
+                      <Ionicons name="document-text-outline" size={14} color="rgb(163, 163, 163)" />
+                      <Text className="ml-1 text-xs text-foreground-muted">
+                        {exercise.note ? 'Note' : 'Add note'}
+                      </Text>
+                    </Pressable>
+                  )}
+
                   {onMakeSuperset && (
                     <Pressable
                       onPress={onMakeSuperset}
@@ -164,6 +192,27 @@ export const ExerciseCard = React.memo(function ExerciseCard({
                     </Pressable>
                   )}
                 </View>
+
+                {/* Note editor / display */}
+                {editingNote ? (
+                  <View className="mb-2">
+                    <TextInput
+                      className="rounded-lg bg-background-100 px-3 py-2 text-sm text-foreground"
+                      placeholder="Add a note for this exercise…"
+                      placeholderTextColor="rgb(115, 115, 115)"
+                      multiline
+                      autoFocus
+                      value={noteInput}
+                      onChangeText={setNoteInput}
+                      onBlur={handleSaveNote}
+                    />
+                  </View>
+                ) : exercise.note ? (
+                  <Pressable onPress={() => setEditingNote(true)} className="mb-2 flex-row items-start gap-1.5">
+                    <Ionicons name="document-text-outline" size={13} color="rgb(115, 115, 115)" style={{ marginTop: 2 }} />
+                    <Text className="flex-1 text-xs italic text-foreground-muted">{exercise.note}</Text>
+                  </Pressable>
+                ) : null}
 
                 {/* Rest time editor */}
                 {editingRest && (

--- a/src/frontend/components/workout/SupersetCard.tsx
+++ b/src/frontend/components/workout/SupersetCard.tsx
@@ -41,6 +41,7 @@ type SupersetCardProps = {
   onStartRest: () => void;
   seriesId?: string | null;
   onSwitchToAlternative?: (workoutExerciseId: string, newExerciseId: string) => void;
+  onSaveNote?: (workoutExerciseId: string, text: string) => void;
 };
 
 export const SupersetCard = React.memo(function SupersetCard({
@@ -62,11 +63,16 @@ export const SupersetCard = React.memo(function SupersetCard({
   onStartRest,
   seriesId,
   onSwitchToAlternative,
+  onSaveNote,
 }: SupersetCardProps) {
   const [showDisbandConfirm, setShowDisbandConfirm] = useState(false);
   const [editingRest, setEditingRest] = useState(false);
   const [localRestSeconds, setLocalRestSeconds] = useState(group.restSeconds);
   const [showRepGoalDialog, setShowRepGoalDialog] = useState(false);
+  const [showNotesDialog, setShowNotesDialog] = useState(false);
+  const [noteInputs, setNoteInputs] = useState<Record<string, string>>(() =>
+    Object.fromEntries(exercises.map((ex) => [ex.id, ex.note ?? '']))
+  );
   const [repGoalInputs, setRepGoalInputs] = useState<Record<string, string>>(() =>
     Object.fromEntries(exercises.map((ex) => [ex.id, formatRepRange(ex.targetRepsMin, ex.targetRepsMax)]))
   );
@@ -85,6 +91,10 @@ export const SupersetCard = React.memo(function SupersetCard({
     setRepGoalInputs(
       Object.fromEntries(exercises.map((ex) => [ex.id, formatRepRange(ex.targetRepsMin, ex.targetRepsMax)]))
     );
+  }, [exercises]);
+
+  useEffect(() => {
+    setNoteInputs(Object.fromEntries(exercises.map((ex) => [ex.id, ex.note ?? ''])));
   }, [exercises]);
 
   // Auto-collapse once when all rounds are fully filled in
@@ -113,6 +123,14 @@ export const SupersetCard = React.memo(function SupersetCard({
       onUpdateTargetReps(ex.id, min, max);
     });
     setShowRepGoalDialog(false);
+  };
+
+  const handleSaveNotes = () => {
+    exercises.forEach((ex) => {
+      const next = noteInputs[ex.id] ?? '';
+      if (next.trim() !== (ex.note ?? '')) onSaveNote?.(ex.id, next);
+    });
+    setShowNotesDialog(false);
   };
 
   return (
@@ -161,6 +179,17 @@ export const SupersetCard = React.memo(function SupersetCard({
             <Text className="ml-1 text-xs text-foreground-muted">Swap</Text>
           </Pressable>
         )}
+        {onSaveNote && (
+          <Pressable
+            onPress={() => setShowNotesDialog(true)}
+            className="flex-row items-center rounded-full bg-background-100 px-3 py-1"
+          >
+            <Ionicons name="document-text-outline" size={14} color="rgb(163, 163, 163)" />
+            <Text className="ml-1 text-xs text-foreground-muted">
+              {exercises.some((ex) => ex.note) ? 'Notes' : 'Add notes'}
+            </Text>
+          </Pressable>
+        )}
       </View>
 
       {!isCollapsed && editingRest && (
@@ -206,6 +235,9 @@ export const SupersetCard = React.memo(function SupersetCard({
                     </Text>
                   ) : null}
                 </Text>
+                {ex.note ? (
+                  <Text className="text-xs italic text-foreground-subtle mb-0.5">{ex.note}</Text>
+                ) : null}
 
                 {set ? (
                   <SetRow
@@ -365,6 +397,53 @@ export const SupersetCard = React.memo(function SupersetCard({
               </Pressable>
               <Pressable
                 onPress={handleSaveRepGoals}
+                className="rounded-lg bg-primary px-4 py-2.5"
+              >
+                <Text className="text-sm font-semibold text-background">Save</Text>
+              </Pressable>
+            </View>
+          </Pressable>
+        </Pressable>
+      </Modal>
+
+      {/* Notes dialog */}
+      <Modal
+        visible={showNotesDialog}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setShowNotesDialog(false)}
+      >
+        <Pressable
+          className="flex-1 items-center justify-center bg-black/60"
+          onPress={() => setShowNotesDialog(false)}
+        >
+          <Pressable
+            className="mx-8 w-full max-w-sm rounded-2xl bg-background-50 p-6"
+            onPress={(e) => e.stopPropagation()}
+          >
+            <Text className="text-lg font-bold text-foreground mb-4">Notes</Text>
+            {exercises.map((ex) => (
+              <View key={ex.id} className="mb-3">
+                <Text className="text-xs font-medium text-foreground-muted mb-1">{ex.exerciseName}</Text>
+                <TextInput
+                  className="rounded-lg bg-background-100 px-3 py-2 text-sm text-foreground"
+                  placeholder="Add a note…"
+                  placeholderTextColor="rgb(115, 115, 115)"
+                  multiline
+                  value={noteInputs[ex.id] ?? ''}
+                  onChangeText={(v) => setNoteInputs((prev) => ({ ...prev, [ex.id]: v }))}
+                />
+              </View>
+            ))}
+            <View className="mt-2 flex-row justify-end gap-3">
+              <Pressable
+                onPress={() => setShowNotesDialog(false)}
+                className="rounded-lg border border-background-100 px-4 py-2.5"
+              >
+                <Text className="text-sm font-medium text-foreground-muted">Cancel</Text>
+              </Pressable>
+              <Pressable
+                onPress={handleSaveNotes}
                 className="rounded-lg bg-primary px-4 py-2.5"
               >
                 <Text className="text-sm font-semibold text-background">Save</Text>

--- a/src/frontend/hooks/useWorkout.ts
+++ b/src/frontend/hooks/useWorkout.ts
@@ -405,3 +405,15 @@ export function useSwitchWorkoutExercise(workoutId: string) {
     },
   });
 }
+
+export function useSetWorkoutExerciseNote(workoutId: string) {
+  const db = useDatabase();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ workoutExerciseId, notes }: { workoutExerciseId: string; notes: string }) =>
+      workoutService.setWorkoutExerciseNote(db, workoutExerciseId, notes),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['workout', workoutId] });
+    },
+  });
+}

--- a/src/shared/types/workout.ts
+++ b/src/shared/types/workout.ts
@@ -105,6 +105,8 @@ export interface WorkoutFull extends Workout {
 export interface WorkoutExerciseFull extends WorkoutExercise {
   exerciseName: string;
   exerciseCategory: string;
+  /** Per-workout note for the currently-selected alternative (exercise option). */
+  note: string | null;
   sets: WorkoutSet[];
 }
 


### PR DESCRIPTION
Bundles two issues plus profile cleanup ahead of the v1.5.0 staging build.

## fix: last-weight reference no longer shows 0 (#29)
`getLatestSetsForExercise` now returns the most recent completed session that actually has a recorded set (non-null weight/duration/distance), so leaving an exercise blank one session falls back to the session before it instead of rendering `0kg`.

- Verified against real device data: a Bench Press whose last 4 sessions were logged blank now correctly shows `Last: 10kg x 5` instead of `Last: 0kg`.

## feat: per-series exercise notes, unique per alternative (#28)
Per-exercise notes attached to the **exercise option** (slot + exercise within a series), so they:
- show on **every workout in the series** (add a note once, see it next session),
- stay **unique per alternative** (switching alternative swaps the note),
- never touch the global `exercises` table.

UI: inline note editor on `ExerciseCard`; per-exercise notes dialog on `SupersetCard` (shown under each exercise on every round).
Schema **v15 → v16 → v17** (v17 moves notes onto the option and migrates existing rows). Migrations verified on-device (`user_version=17`, existing note preserved & shared across the series).

## feat: profile polish
- Version was hardcoded `v1.0.0` (releases had reached v1.4.0). Bumped `app.json` → **1.5.0**, now read via `Constants.expoConfig.version` so it can't drift.
- Added a **"Check for Updates"** button → GitHub releases page.
- Removed the stale **Coming Soon** block.

## Verification
- `pnpm exec tsc --noEmit` clean.
- Ran on a physical device (Android 16) throughout: migrations applied, no JS/SQLite errors, both features and profile changes confirmed live.

Merging to `master` triggers the staging APK build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)