### PR TITLE
feat: Multiple gyms — per-gym sessions, last weights, and active alternatives

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -8,6 +8,7 @@ import { useSettingsStore } from '@backend/store/settingsStore';
 import { useDatabase } from '@frontend/hooks/useDatabase';
 import { useBodyWeightHistory, useLogBodyWeight, useDeleteBodyWeight } from '@frontend/hooks/useBodyWeight';
 import { WeightSparkline } from '@frontend/components/profile/WeightSparkline';
+import { GymManager } from '@frontend/components/profile/GymManager';
 import { SelectPicker } from '@frontend/components/overlay/SelectPicker';
 import { ConfirmDialog } from '@frontend/components/overlay/ConfirmDialog';
 import { formatWeight } from '@shared/utils/formatting';
@@ -162,6 +163,9 @@ export default function ProfileScreen() {
             Currently using {units === 'metric' ? 'metric (kg, km)' : 'imperial (lb, mi)'}
           </Text>
         </View>
+
+        {/* Gyms */}
+        <GymManager />
 
         {/* Rest timer default */}
         <View className="mx-4 mt-3 rounded-xl bg-background-50 p-4">

--- a/app/(tabs)/workouts.tsx
+++ b/app/(tabs)/workouts.tsx
@@ -7,6 +7,8 @@ import { EmptyState } from '@frontend/components/EmptyState';
 import { ConfirmDialog } from '@frontend/components/overlay/ConfirmDialog';
 import { useWorkoutHistory, useWorkoutGroupDetails } from '@frontend/hooks/useHistory';
 import { useRepeatWorkout, useDeleteWorkout, useDeleteWorkouts, useContinueWorkout, useForceContinueWorkout, useUpdateWorkoutName, useMoveSeriesUp, useMoveSeriesDown } from '@frontend/hooks/useWorkout';
+import { useGymGate } from '@frontend/hooks/useGymGate';
+import { useAllGyms } from '@frontend/hooks/useGyms';
 import { useRouter } from 'expo-router';
 import { formatDate, formatDuration, parseUTCTimestamp } from '@shared/utils/formatting';
 import { cn } from '@frontend/lib/utils';
@@ -74,6 +76,16 @@ export default function WorkoutsScreen() {
   const forceContinueWorkout = useForceContinueWorkout();
   const moveSeriesUp = useMoveSeriesUp();
   const moveSeriesDown = useMoveSeriesDown();
+  const { gate, gymGate } = useGymGate();
+
+  const { data: allGyms } = useAllGyms();
+  const gymNames = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const g of allGyms ?? []) map.set(g.id, g.name);
+    return map;
+  }, [allGyms]);
+  // Only surface the gym label once more than one gym has ever existed.
+  const showGymLabels = (allGyms?.length ?? 0) > 1;
 
   const [selectedGroup, setSelectedGroup] = useState<WorkoutGroup | null>(null);
   const [confirmDeleteGroup, setConfirmDeleteGroup] = useState<WorkoutGroup | null>(null);
@@ -116,14 +128,16 @@ export default function WorkoutsScreen() {
     setExpandedSessions(new Set());
   }, [selectedGroup]);
 
-  const handleRepeat = async (workoutId: string) => {
-    try {
-      const newWorkout = await repeatWorkout.mutateAsync(workoutId);
-      router.replace(`/workout/${newWorkout.id}`);
-    } catch (e) {
-      // mutation errors shown inline via repeatWorkout.error
-      if (__DEV__) console.warn('Repeat workout failed:', e);
-    }
+  const handleRepeat = (workoutId: string) => {
+    gate(async (gymId) => {
+      try {
+        const newWorkout = await repeatWorkout.mutateAsync({ sourceWorkoutId: workoutId, gymId });
+        router.replace(`/workout/${newWorkout.id}`);
+      } catch (e) {
+        // mutation errors shown inline via repeatWorkout.error
+        if (__DEV__) console.warn('Repeat workout failed:', e);
+      }
+    });
   };
 
   const handleDeleteGroup = async (group: WorkoutGroup) => {
@@ -336,7 +350,15 @@ export default function WorkoutsScreen() {
                           <Text className="text-sm font-semibold text-foreground">
                             {formatDate(session.startedAt)}
                           </Text>
-                          <Text className="text-xs text-foreground-muted mt-0.5">{formatDuration(duration)}</Text>
+                          <View className="flex-row items-center gap-2 mt-0.5">
+                            <Text className="text-xs text-foreground-muted">{formatDuration(duration)}</Text>
+                            {showGymLabels && session.gymId && gymNames.has(session.gymId) && (
+                              <View className="flex-row items-center gap-1">
+                                <Ionicons name="location-outline" size={11} color="rgb(115, 115, 115)" />
+                                <Text className="text-xs text-foreground-subtle">{gymNames.get(session.gymId)}</Text>
+                              </View>
+                            )}
+                          </View>
                         </View>
                         <View className="flex-row items-center gap-2">
                           <Pressable
@@ -481,6 +503,8 @@ export default function WorkoutsScreen() {
         onConfirm={handleForceContinue}
         onCancel={() => setConfirmContinueId(null)}
       />
+
+      {gymGate}
     </View>
   );
 }

--- a/app/workout/[id].tsx
+++ b/app/workout/[id].tsx
@@ -65,7 +65,7 @@ function ActiveWorkoutContent({ workout, id }: { workout: WorkoutFull; id: strin
     () => workout.exercises.map((ex) => ex.exerciseId),
     [workout.exercises]
   );
-  const { data: previousSetsMap } = usePreviousSetsForExercises(exerciseIds, workout.seriesId);
+  const { data: previousSetsMap } = usePreviousSetsForExercises(exerciseIds, workout.seriesId, workout.gymId);
 
   const addExercise = useAddExercise(id);
   const logSet = useLogSet(id);

--- a/app/workout/new.tsx
+++ b/app/workout/new.tsx
@@ -8,6 +8,7 @@ import * as workoutTypeModel from '@backend/models/workoutType';
 import { useDatabase } from '@frontend/hooks/useDatabase';
 import { useStartWorkout } from '@frontend/hooks/useWorkout';
 import { useTodayScheduledWorkouts, useStartScheduledWorkout } from '@frontend/hooks/useScheduledWorkouts';
+import { useGymGate } from '@frontend/hooks/useGymGate';
 import type { WorkoutType } from '@shared/types/workout';
 import type { ScheduledWorkout } from '@shared/types/scheduledWorkout';
 
@@ -28,6 +29,7 @@ export default function NewWorkoutScreen() {
   const startWorkout = useStartWorkout();
   const { data: todayPlanned } = useTodayScheduledWorkouts();
   const startScheduled = useStartScheduledWorkout();
+  const { gate, gymGate } = useGymGate();
 
   const unstartedPlanned = todayPlanned?.filter((s) => !s.startedWorkoutId) ?? [];
 
@@ -36,27 +38,32 @@ export default function NewWorkoutScreen() {
     queryFn: () => workoutTypeModel.getAll(db),
   });
 
-  const handleStart = async () => {
+  const handleStart = () => {
     if (!selectedType) return;
-    try {
-      const workout = await startWorkout.mutateAsync({
-        typeId: selectedType.id,
-        name: workoutName.trim() || undefined,
-      });
-      router.replace(`/workout/${workout.id}`);
-    } catch (e) {
-      // mutation errors shown inline via startWorkout.error
-      if (__DEV__) console.warn('Start workout failed:', e);
-    }
+    gate(async (gymId) => {
+      try {
+        const workout = await startWorkout.mutateAsync({
+          typeId: selectedType.id,
+          name: workoutName.trim() || undefined,
+          gymId,
+        });
+        router.replace(`/workout/${workout.id}`);
+      } catch (e) {
+        // mutation errors shown inline via startWorkout.error
+        if (__DEV__) console.warn('Start workout failed:', e);
+      }
+    });
   };
 
-  const handleStartPlanned = async (s: ScheduledWorkout) => {
-    try {
-      const workout = await startScheduled.mutateAsync({ scheduledId: s.id, seriesId: s.seriesId });
-      router.replace(`/workout/${workout.id}`);
-    } catch (e) {
-      if (__DEV__) console.warn('Start planned workout failed:', e);
-    }
+  const handleStartPlanned = (s: ScheduledWorkout) => {
+    gate(async (gymId) => {
+      try {
+        const workout = await startScheduled.mutateAsync({ scheduledId: s.id, seriesId: s.seriesId, gymId });
+        router.replace(`/workout/${workout.id}`);
+      } catch (e) {
+        if (__DEV__) console.warn('Start planned workout failed:', e);
+      }
+    });
   };
 
   const handlePlannedPress = () => {
@@ -158,6 +165,7 @@ export default function NewWorkoutScreen() {
             <Text className="mt-3 text-sm text-foreground-muted">Starting workout...</Text>
           </View>
         )}
+        {gymGate}
       </View>
     );
   }
@@ -210,6 +218,7 @@ export default function NewWorkoutScreen() {
             </Pressable>
           )}
         />
+        {gymGate}
       </View>
     );
   }
@@ -289,6 +298,7 @@ export default function NewWorkoutScreen() {
           </Text>
         </Pressable>
       </View>
+      {gymGate}
     </View>
   );
 }

--- a/app/workout/repeat.tsx
+++ b/app/workout/repeat.tsx
@@ -6,6 +6,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { EmptyState } from '@frontend/components/EmptyState';
 import { useWorkoutHistory } from '@frontend/hooks/useHistory';
 import { useRepeatWorkout } from '@frontend/hooks/useWorkout';
+import { useGymGate } from '@frontend/hooks/useGymGate';
 import { cn } from '@frontend/lib/utils';
 import type { WorkoutSummary } from '@shared/types/workout';
 
@@ -47,17 +48,20 @@ export default function RepeatWorkoutScreen() {
   const router = useRouter();
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } = useWorkoutHistory();
   const repeatWorkout = useRepeatWorkout();
+  const { gate, gymGate } = useGymGate();
 
   const workouts = useMemo(() => data?.pages.flatMap((page) => page) ?? [], [data]);
   const groups = useMemo(() => groupWorkouts(workouts), [workouts]);
 
-  const handleRepeat = async (workoutId: string) => {
-    try {
-      const newWorkout = await repeatWorkout.mutateAsync(workoutId);
-      router.replace(`/workout/${newWorkout.id}`);
-    } catch (e) {
-      if (__DEV__) console.warn('Repeat workout failed:', e);
-    }
+  const handleRepeat = (workoutId: string) => {
+    gate(async (gymId) => {
+      try {
+        const newWorkout = await repeatWorkout.mutateAsync({ sourceWorkoutId: workoutId, gymId });
+        router.replace(`/workout/${newWorkout.id}`);
+      } catch (e) {
+        if (__DEV__) console.warn('Repeat workout failed:', e);
+      }
+    });
   };
 
   return (
@@ -132,6 +136,7 @@ export default function RepeatWorkoutScreen() {
           </Pressable>
         )}
       />
+      {gymGate}
     </View>
   );
 }

--- a/src/backend/database/migrations.ts
+++ b/src/backend/database/migrations.ts
@@ -439,6 +439,34 @@ const migrations: Migration[] = [
     `);
     await db.execAsync(`DROP TABLE workout_exercise_notes;`);
   },
+  // v17 → v18: Multiple gyms. Add a gyms table and tag each workout with the gym it was
+  // done at. Creates a single default gym and attributes all existing history to it, so
+  // gym becomes a second scoping dimension alongside series_id (per-gym last weights and
+  // per-gym active alternatives are layered on top in later work).
+  async (db) => {
+    await db.execAsync(`
+      CREATE TABLE gyms (
+        id TEXT PRIMARY KEY NOT NULL,
+        name TEXT NOT NULL,
+        is_default INTEGER NOT NULL DEFAULT 0,
+        archived_at TEXT,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE(name COLLATE NOCASE)
+      );
+
+      ALTER TABLE workouts ADD COLUMN gym_id TEXT REFERENCES gyms(id);
+      CREATE INDEX idx_workouts_series_gym ON workouts(series_id, gym_id);
+    `);
+
+    // Seed the default gym and attribute all existing workouts to it.
+    const defaultGymId = Crypto.randomUUID();
+    await db.runAsync(
+      `INSERT INTO gyms (id, name, is_default, sort_order) VALUES (?, 'My Gym', 1, 0)`,
+      defaultGymId
+    );
+    await db.runAsync(`UPDATE workouts SET gym_id = ? WHERE gym_id IS NULL`, defaultGymId);
+  },
 ];
 
 export async function runMigrations(db: SQLite.SQLiteDatabase): Promise<void> {

--- a/src/backend/models/gym.ts
+++ b/src/backend/models/gym.ts
@@ -1,0 +1,93 @@
+/** Gym model - manages the gyms table (create, list, rename, archive). */
+import type * as SQLite from 'expo-sqlite';
+import * as Crypto from 'expo-crypto';
+import type { Gym } from '@shared/types/gym';
+
+interface GymRow {
+  id: string;
+  name: string;
+  is_default: number;
+  archived_at: string | null;
+  sort_order: number;
+  created_at: string;
+}
+
+function mapRow(row: GymRow): Gym {
+  return {
+    id: row.id,
+    name: row.name,
+    isDefault: row.is_default === 1,
+    archivedAt: row.archived_at,
+    sortOrder: row.sort_order,
+    createdAt: row.created_at,
+  };
+}
+
+export async function create(db: SQLite.SQLiteDatabase, name: string): Promise<Gym> {
+  const id = Crypto.randomUUID();
+  await db.runAsync(
+    `INSERT INTO gyms (id, name, is_default, sort_order, created_at)
+     VALUES (?, ?, 0, (SELECT COALESCE(MAX(sort_order), 0) + 1 FROM gyms), datetime('now'))`,
+    id,
+    name
+  );
+  const gym = await getById(db, id);
+  if (!gym) throw new Error(`Failed to create gym with id ${id}`);
+  return gym;
+}
+
+export async function getById(db: SQLite.SQLiteDatabase, id: string): Promise<Gym | null> {
+  const row = await db.getFirstAsync<GymRow>(`SELECT * FROM gyms WHERE id = ?`, id);
+  return row ? mapRow(row) : null;
+}
+
+/** All gyms, optionally including archived ones. Active gyms first, by sort order. */
+export async function getAll(
+  db: SQLite.SQLiteDatabase,
+  includeArchived = false
+): Promise<Gym[]> {
+  const rows = await db.getAllAsync<GymRow>(
+    `SELECT * FROM gyms
+     ${includeArchived ? '' : 'WHERE archived_at IS NULL'}
+     ORDER BY sort_order ASC`
+  );
+  return rows.map(mapRow);
+}
+
+/** Non-archived gyms only. */
+export async function getActive(db: SQLite.SQLiteDatabase): Promise<Gym[]> {
+  return getAll(db, false);
+}
+
+export async function getActiveCount(db: SQLite.SQLiteDatabase): Promise<number> {
+  const row = await db.getFirstAsync<{ count: number }>(
+    `SELECT COUNT(*) as count FROM gyms WHERE archived_at IS NULL`
+  );
+  return row?.count ?? 0;
+}
+
+export async function getDefault(db: SQLite.SQLiteDatabase): Promise<Gym | null> {
+  const row = await db.getFirstAsync<GymRow>(
+    `SELECT * FROM gyms WHERE is_default = 1 LIMIT 1`
+  );
+  return row ? mapRow(row) : null;
+}
+
+export async function rename(
+  db: SQLite.SQLiteDatabase,
+  id: string,
+  name: string
+): Promise<void> {
+  await db.runAsync(`UPDATE gyms SET name = ? WHERE id = ?`, name, id);
+}
+
+export async function archive(db: SQLite.SQLiteDatabase, id: string): Promise<void> {
+  await db.runAsync(
+    `UPDATE gyms SET archived_at = datetime('now') WHERE id = ? AND is_default = 0`,
+    id
+  );
+}
+
+export async function unarchive(db: SQLite.SQLiteDatabase, id: string): Promise<void> {
+  await db.runAsync(`UPDATE gyms SET archived_at = NULL WHERE id = ?`, id);
+}

--- a/src/backend/models/workout.ts
+++ b/src/backend/models/workout.ts
@@ -7,6 +7,7 @@ interface WorkoutRow {
   id: string;
   workout_type_id: string;
   series_id: string | null;
+  gym_id: string | null;
   name: string | null;
   status: string;
   started_at: string;
@@ -22,6 +23,7 @@ function mapRow(row: WorkoutRow): Workout {
     id: row.id,
     workoutTypeId: row.workout_type_id,
     seriesId: row.series_id,
+    gymId: row.gym_id,
     name: row.name,
     status: row.status as WorkoutStatus,
     startedAt: row.started_at,
@@ -38,21 +40,52 @@ export async function create(
   db: SQLite.SQLiteDatabase,
   workoutTypeId: string,
   name?: string | null,
-  seriesId?: string | null
+  seriesId?: string | null,
+  gymId?: string | null
 ): Promise<Workout> {
   const id = Crypto.randomUUID();
   await db.runAsync(
-    `INSERT INTO workouts (id, workout_type_id, name, status, started_at, last_started_at, created_at, series_id)
-     VALUES (?, ?, ?, ?, datetime('now'), datetime('now'), datetime('now'), ?)`,
+    `INSERT INTO workouts (id, workout_type_id, name, status, started_at, last_started_at, created_at, series_id, gym_id)
+     VALUES (?, ?, ?, ?, datetime('now'), datetime('now'), datetime('now'), ?, ?)`,
     id,
     workoutTypeId,
     name ?? null,
     WorkoutStatus.InProgress,
-    seriesId ?? null
+    seriesId ?? null,
+    gymId ?? null
   );
   const workout = await getById(db, id);
   if (!workout) throw new Error(`Failed to create workout with id ${id}`);
   return workout;
+}
+
+/**
+ * Most recent completed workout in a series, optionally scoped to a gym. Drives per-gym
+ * structure resolution: when starting at a gym, clone that gym's last session if it exists.
+ * Returns null when the (series[, gym]) combination has no completed workouts yet.
+ */
+export async function getLatestCompletedInSeries(
+  db: SQLite.SQLiteDatabase,
+  seriesId: string,
+  gymId?: string | null
+): Promise<Workout | null> {
+  const row = gymId
+    ? await db.getFirstAsync<WorkoutRow>(
+        `SELECT * FROM workouts
+         WHERE series_id = ? AND gym_id = ? AND status = ?
+         ORDER BY completed_at DESC LIMIT 1`,
+        seriesId,
+        gymId,
+        WorkoutStatus.Completed
+      )
+    : await db.getFirstAsync<WorkoutRow>(
+        `SELECT * FROM workouts
+         WHERE series_id = ? AND status = ?
+         ORDER BY completed_at DESC LIMIT 1`,
+        seriesId,
+        WorkoutStatus.Completed
+      );
+  return row ? mapRow(row) : null;
 }
 
 export async function getActive(

--- a/src/backend/models/workoutSet.ts
+++ b/src/backend/models/workoutSet.ts
@@ -163,11 +163,15 @@ export async function getByWorkout(
  * the last session where something was actually entered — leaving an exercise blank one
  * session falls back to the session before it rather than showing 0.
  * If seriesId is null/undefined (standalone workout), returns empty.
+ * When gymId is provided, the reference is scoped to that gym only (no cross-gym fallback):
+ * the "last time" weights stay explicit per gym, so an exercise never trained at a gym
+ * shows no reference there.
  */
 export async function getLatestSetsForExercise(
   db: SQLite.SQLiteDatabase,
   exerciseId: string,
-  seriesId?: string | null
+  seriesId?: string | null,
+  gymId?: string | null
 ): Promise<WorkoutSet[]> {
   // New standalone workouts (no series) should show no reference weights
   if (!seriesId) return [];
@@ -180,6 +184,7 @@ export async function getLatestSetsForExercise(
      WHERE we.exercise_id = ?
        AND w.status = 'completed'
        AND w.series_id = ?
+       ${gymId ? 'AND w.gym_id = ?' : ''}
        AND EXISTS (
          SELECT 1 FROM workout_sets ws
          WHERE ws.workout_exercise_id = we.id
@@ -187,8 +192,7 @@ export async function getLatestSetsForExercise(
        )
      ORDER BY w.completed_at DESC
      LIMIT 1`,
-    exerciseId,
-    seriesId
+    ...(gymId ? [exerciseId, seriesId, gymId] : [exerciseId, seriesId])
   );
   if (!latest) return [];
 
@@ -202,12 +206,14 @@ export async function getLatestSetsForExercise(
 /**
  * Batch version: returns previous sets for multiple exercises at once.
  * If seriesId is null/undefined, returns empty (standalone workout).
+ * When gymId is provided, the reference is scoped to that gym (see getLatestSetsForExercise).
  * Returns a Map keyed by exerciseId.
  */
 export async function getLatestSetsForExercises(
   db: SQLite.SQLiteDatabase,
   exerciseIds: string[],
-  seriesId?: string | null
+  seriesId?: string | null,
+  gymId?: string | null
 ): Promise<Map<string, WorkoutSet[]>> {
   const result = new Map<string, WorkoutSet[]>();
   if (exerciseIds.length === 0) return result;
@@ -215,7 +221,7 @@ export async function getLatestSetsForExercises(
   // Fetch in parallel
   await Promise.all(
     exerciseIds.map(async (eid) => {
-      const sets = await getLatestSetsForExercise(db, eid, seriesId);
+      const sets = await getLatestSetsForExercise(db, eid, seriesId, gymId);
       if (sets.length > 0) result.set(eid, sets);
     })
   );

--- a/src/backend/services/gymService.ts
+++ b/src/backend/services/gymService.ts
@@ -1,0 +1,47 @@
+/** Gym service - business logic for managing training locations (gyms). */
+import type * as SQLite from 'expo-sqlite';
+import * as gymModel from '@backend/models/gym';
+import type { Gym } from '@shared/types/gym';
+
+export async function listGyms(
+  db: SQLite.SQLiteDatabase,
+  includeArchived = false
+): Promise<Gym[]> {
+  return gymModel.getAll(db, includeArchived);
+}
+
+export async function createGym(db: SQLite.SQLiteDatabase, name: string): Promise<Gym> {
+  const trimmed = name.trim();
+  if (!trimmed) throw new Error('Gym name cannot be empty.');
+  return gymModel.create(db, trimmed);
+}
+
+export async function renameGym(
+  db: SQLite.SQLiteDatabase,
+  id: string,
+  name: string
+): Promise<void> {
+  const trimmed = name.trim();
+  if (!trimmed) throw new Error('Gym name cannot be empty.');
+  await gymModel.rename(db, id, trimmed);
+}
+
+export async function archiveGym(db: SQLite.SQLiteDatabase, id: string): Promise<void> {
+  const gym = await gymModel.getById(db, id);
+  if (gym?.isDefault) throw new Error('The default gym cannot be archived.');
+  await gymModel.archive(db, id);
+}
+
+export async function unarchiveGym(db: SQLite.SQLiteDatabase, id: string): Promise<void> {
+  await gymModel.unarchive(db, id);
+}
+
+/** Whether the gym picker should be shown at workout start (≥ 2 active gyms). */
+export async function shouldPromptForGym(db: SQLite.SQLiteDatabase): Promise<boolean> {
+  return (await gymModel.getActiveCount(db)) >= 2;
+}
+
+/** The gym to attribute a session to when no explicit choice is made (single-gym case). */
+export async function getDefaultGym(db: SQLite.SQLiteDatabase): Promise<Gym | null> {
+  return gymModel.getDefault(db);
+}

--- a/src/backend/services/scheduledWorkoutService.ts
+++ b/src/backend/services/scheduledWorkoutService.ts
@@ -47,7 +47,8 @@ export async function cancelScheduled(
 export async function startScheduledWorkout(
   db: SQLite.SQLiteDatabase,
   scheduledId: string,
-  seriesId: string
+  seriesId: string,
+  gymId?: string | null
 ): Promise<Workout> {
   // Find the latest completed workout in this series to repeat
   const latest = await db.getFirstAsync<{ id: string }>(
@@ -57,7 +58,8 @@ export async function startScheduledWorkout(
   if (!latest) {
     throw new Error('No completed workout found in this series to repeat');
   }
-  const workout = await workoutService.repeatWorkout(db, latest.id);
+  // repeatWorkout re-resolves the clone source per gym (falling back to this latest one).
+  const workout = await workoutService.repeatWorkout(db, latest.id, gymId);
   await scheduledWorkoutModel.markStarted(db, scheduledId, workout.id);
   return workout;
 }

--- a/src/backend/services/workoutService.ts
+++ b/src/backend/services/workoutService.ts
@@ -12,6 +12,7 @@ import * as exerciseSlotModel from '@backend/models/exerciseSlot';
 import * as exerciseOptionModel from '@backend/models/exerciseOption';
 import * as exerciseAlternativeModel from '@backend/models/exerciseAlternative';
 import * as exerciseOptionNoteModel from '@backend/models/exerciseOptionNote';
+import * as gymModel from '@backend/models/gym';
 import type { ExerciseAlternative } from '@backend/models/exerciseAlternative';
 import { getDefaultRestSeconds } from '@backend/services/timerService';
 import { APP_CONFIG } from '@config/app';
@@ -25,7 +26,8 @@ export async function startWorkout(
   db: SQLite.SQLiteDatabase,
   typeId: string,
   name?: string | null,
-  seriesId?: string | null
+  seriesId?: string | null,
+  gymId?: string | null
 ): Promise<Workout> {
   const active = await workout.getActive(db);
   if (active) {
@@ -41,7 +43,10 @@ export async function startWorkout(
     resolvedSeriesId = series.id;
   }
 
-  return workout.create(db, typeId, name, resolvedSeriesId);
+  // Fall back to the default gym when the caller didn't pick one (single-gym case).
+  const resolvedGymId = gymId ?? (await gymModel.getDefault(db))?.id ?? null;
+
+  return workout.create(db, typeId, name, resolvedSeriesId, resolvedGymId);
 }
 
 export async function addExerciseToWorkout(
@@ -353,6 +358,8 @@ export async function getWorkoutSummaries(
   type SummaryRow = {
     id: string;
     series_id: string | null;
+    gym_id: string | null;
+    gym_name: string | null;
     name: string | null;
     workout_type_name: string;
     status: string;
@@ -368,6 +375,8 @@ export async function getWorkoutSummaries(
     `SELECT
        w.id,
        w.series_id,
+       w.gym_id,
+       g.name             AS gym_name,
        COALESCE(ws_series.name, w.name) AS name,
        wt.name            AS workout_type_name,
        w.status,
@@ -380,6 +389,7 @@ export async function getWorkoutSummaries(
      FROM workouts w
      JOIN workout_types wt ON wt.id = w.workout_type_id
      LEFT JOIN workout_series ws_series ON ws_series.id = w.series_id
+     LEFT JOIN gyms g ON g.id = w.gym_id
      LEFT JOIN workout_exercises we ON we.workout_id = w.id
      LEFT JOIN workout_sets ws ON ws.workout_exercise_id = we.id
      WHERE w.status = ?
@@ -416,6 +426,8 @@ export async function getWorkoutSummaries(
   return rows.map((row) => ({
     id: row.id,
     seriesId: row.series_id,
+    gymId: row.gym_id,
+    gymName: row.gym_name,
     name: row.name,
     workoutTypeName: row.workout_type_name,
     status: row.status as WorkoutStatus,
@@ -431,22 +443,37 @@ export async function getWorkoutSummaries(
 
 export async function repeatWorkout(
   db: SQLite.SQLiteDatabase,
-  sourceWorkoutId: string
+  sourceWorkoutId: string,
+  gymId?: string | null
 ): Promise<Workout> {
-  const source = await getFullWorkout(db, sourceWorkoutId);
-  if (!source) throw new Error('Source workout not found');
+  const requested = await getFullWorkout(db, sourceWorkoutId);
+  if (!requested) throw new Error('Source workout not found');
+
+  // Post-migration all workouts have a series_id; create one only as a safety fallback
+  let seriesId = requested.seriesId;
+  if (!seriesId) {
+    const series = await workoutSeriesModel.create(db, requested.name || requested.workoutType.name);
+    seriesId = series.id;
+    await db.runAsync(`UPDATE workouts SET series_id = ? WHERE id = ?`, seriesId, requested.id);
+  }
+
+  const resolvedGymId = gymId ?? (await gymModel.getDefault(db))?.id ?? null;
+
+  // Per-gym active alternatives: clone the structure from that gym's most recent session of
+  // this series, so each gym carries its own active exercise per slot. Fall back to the
+  // requested workout when this gym has no history in the series yet.
+  let source = requested;
+  if (resolvedGymId && seriesId) {
+    const gymLatest = await workout.getLatestCompletedInSeries(db, seriesId, resolvedGymId);
+    if (gymLatest && gymLatest.id !== requested.id) {
+      const gymLatestFull = await getFullWorkout(db, gymLatest.id);
+      if (gymLatestFull) source = gymLatestFull;
+    }
+  }
 
   const name = source.name || source.workoutType.name;
 
-  // Post-migration all workouts have a series_id; create one only as a safety fallback
-  let seriesId = source.seriesId;
-  if (!seriesId) {
-    const series = await workoutSeriesModel.create(db, source.name || source.workoutType.name);
-    seriesId = series.id;
-    await db.runAsync(`UPDATE workouts SET series_id = ? WHERE id = ?`, seriesId, source.id);
-  }
-
-  const newWorkout = await startWorkout(db, source.workoutTypeId, name, seriesId);
+  const newWorkout = await startWorkout(db, source.workoutTypeId, name, seriesId, resolvedGymId);
 
   // Map old superset group IDs to new ones for the repeated workout
   const groupIdMap = new Map<string, string>();
@@ -476,9 +503,10 @@ export async function repeatWorkout(
 export async function getPreviousSetsForExercises(
   db: SQLite.SQLiteDatabase,
   exerciseIds: string[],
-  seriesId?: string | null
+  seriesId?: string | null,
+  gymId?: string | null
 ): Promise<Map<string, WorkoutSet[]>> {
-  return workoutSet.getLatestSetsForExercises(db, exerciseIds, seriesId);
+  return workoutSet.getLatestSetsForExercises(db, exerciseIds, seriesId, gymId);
 }
 
 export async function getFullWorkoutsByIds(
@@ -531,6 +559,8 @@ export async function getWorkoutSummariesByDateRange(
   type DateRangeSummaryRow = {
     id: string;
     series_id: string | null;
+    gym_id: string | null;
+    gym_name: string | null;
     name: string | null;
     workout_type_name: string;
     status: string;
@@ -546,6 +576,8 @@ export async function getWorkoutSummariesByDateRange(
     `SELECT
        w.id,
        w.series_id,
+       w.gym_id,
+       g.name             AS gym_name,
        COALESCE(ws_series.name, w.name) AS name,
        wt.name            AS workout_type_name,
        w.status,
@@ -558,6 +590,7 @@ export async function getWorkoutSummariesByDateRange(
      FROM workouts w
      JOIN workout_types wt ON wt.id = w.workout_type_id
      LEFT JOIN workout_series ws_series ON ws_series.id = w.series_id
+     LEFT JOIN gyms g ON g.id = w.gym_id
      LEFT JOIN workout_exercises we ON we.workout_id = w.id
      LEFT JOIN workout_sets ws ON ws.workout_exercise_id = we.id
      WHERE w.status = ? AND w.started_at >= ? AND w.started_at <= ?
@@ -592,6 +625,8 @@ export async function getWorkoutSummariesByDateRange(
   return rows.map((row) => ({
     id: row.id,
     seriesId: row.series_id,
+    gymId: row.gym_id,
+    gymName: row.gym_name,
     name: row.name,
     workoutTypeName: row.workout_type_name,
     status: row.status as WorkoutStatus,

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -2,7 +2,7 @@
 export const APP_CONFIG = {
   database: {
     name: 'vext.db',
-    schemaVersion: 17,
+    schemaVersion: 18,
   },
   defaults: {
     restSeconds: {

--- a/src/frontend/components/profile/GymManager.tsx
+++ b/src/frontend/components/profile/GymManager.tsx
@@ -1,0 +1,144 @@
+/** GymManager - settings section to add, rename, and archive gyms (training locations). */
+import React, { useMemo, useState } from 'react';
+import { View, Text, TextInput, Pressable } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import {
+  useAllGyms,
+  useCreateGym,
+  useRenameGym,
+  useArchiveGym,
+  useUnarchiveGym,
+} from '@frontend/hooks/useGyms';
+import type { Gym } from '@shared/types/gym';
+
+export function GymManager() {
+  const { data: gyms } = useAllGyms();
+  const createGym = useCreateGym();
+  const renameGym = useRenameGym();
+  const archiveGym = useArchiveGym();
+  const unarchiveGym = useUnarchiveGym();
+
+  const [newName, setNewName] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState('');
+
+  const { active, archived } = useMemo(() => {
+    const active: Gym[] = [];
+    const archived: Gym[] = [];
+    for (const g of gyms ?? []) (g.archivedAt ? archived : active).push(g);
+    return { active, archived };
+  }, [gyms]);
+
+  const handleAdd = () => {
+    const name = newName.trim();
+    if (!name) return;
+    createGym.mutate(name, { onSuccess: () => setNewName('') });
+  };
+
+  const handleSaveEdit = (id: string) => {
+    const name = editValue.trim();
+    if (name) renameGym.mutate({ id, name });
+    setEditingId(null);
+  };
+
+  return (
+    <View className="mx-4 mt-3 rounded-xl bg-background-50 p-4">
+      <Text className="text-sm font-medium text-foreground-muted mb-3">Gyms</Text>
+
+      {/* Active gyms */}
+      {active.map((gym) => (
+        <View key={gym.id} className="flex-row items-center justify-between py-2 border-b border-background-100">
+          {editingId === gym.id ? (
+            <>
+              <TextInput
+                autoFocus
+                className="flex-1 h-9 rounded-lg bg-background-100 px-3 text-sm text-foreground mr-2"
+                value={editValue}
+                onChangeText={setEditValue}
+                onSubmitEditing={() => handleSaveEdit(gym.id)}
+              />
+              <Pressable onPress={() => handleSaveEdit(gym.id)} className="p-1.5">
+                <Ionicons name="checkmark" size={18} color="rgb(52, 211, 153)" />
+              </Pressable>
+              <Pressable onPress={() => setEditingId(null)} className="p-1.5">
+                <Ionicons name="close" size={18} color="rgb(163, 163, 163)" />
+              </Pressable>
+            </>
+          ) : (
+            <>
+              <View className="flex-row items-center gap-2 flex-1">
+                <Ionicons name="location-outline" size={18} color="rgb(163, 163, 163)" />
+                <Text className="text-base text-foreground">{gym.name}</Text>
+                {gym.isDefault && (
+                  <View className="rounded-full bg-background-100 px-2 py-0.5">
+                    <Text className="text-[10px] font-semibold text-foreground-subtle">DEFAULT</Text>
+                  </View>
+                )}
+              </View>
+              <Pressable
+                onPress={() => {
+                  setEditingId(gym.id);
+                  setEditValue(gym.name);
+                }}
+                className="p-1.5"
+              >
+                <Ionicons name="pencil-outline" size={16} color="rgb(163, 163, 163)" />
+              </Pressable>
+              {!gym.isDefault && (
+                <Pressable onPress={() => archiveGym.mutate(gym.id)} className="p-1.5">
+                  <Ionicons name="archive-outline" size={16} color="rgb(163, 163, 163)" />
+                </Pressable>
+              )}
+            </>
+          )}
+        </View>
+      ))}
+
+      {/* Add gym */}
+      <View className="flex-row items-center gap-2 mt-3">
+        <TextInput
+          className="flex-1 h-10 rounded-lg bg-background-100 px-3 text-sm text-foreground"
+          placeholder="Add a gym"
+          placeholderTextColor="rgb(115, 115, 115)"
+          value={newName}
+          onChangeText={setNewName}
+          onSubmitEditing={handleAdd}
+        />
+        <Pressable
+          onPress={handleAdd}
+          disabled={createGym.isPending || !newName.trim()}
+          className="rounded-lg bg-primary px-4 h-10 items-center justify-center"
+        >
+          <Text className="text-sm font-semibold text-background">
+            {createGym.isPending ? '...' : 'Add'}
+          </Text>
+        </Pressable>
+      </View>
+      {createGym.error && (
+        <Text className="text-xs text-destructive mt-2">{(createGym.error as Error).message}</Text>
+      )}
+      {archiveGym.error && (
+        <Text className="text-xs text-destructive mt-2">{(archiveGym.error as Error).message}</Text>
+      )}
+
+      {/* Archived gyms */}
+      {archived.length > 0 && (
+        <View className="mt-4">
+          <Text className="text-xs font-medium text-foreground-subtle mb-2">Archived</Text>
+          {archived.map((gym) => (
+            <View key={gym.id} className="flex-row items-center justify-between py-2">
+              <Text className="text-sm text-foreground-subtle">{gym.name}</Text>
+              <Pressable
+                onPress={() => unarchiveGym.mutate(gym.id)}
+                className="flex-row items-center gap-1 rounded-lg bg-background-100 px-3 py-1.5"
+              >
+                <Ionicons name="refresh-outline" size={14} color="rgb(163, 163, 163)" />
+                <Text className="text-xs font-medium text-foreground-muted">Restore</Text>
+              </Pressable>
+            </View>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}

--- a/src/frontend/hooks/useGymGate.tsx
+++ b/src/frontend/hooks/useGymGate.tsx
@@ -1,0 +1,45 @@
+/**
+ * useGymGate - gates a workout-start action behind a gym choice.
+ *
+ * When there are 2+ active gyms, calling `gate(onChosen)` opens a picker (nothing
+ * pre-selected) and invokes `onChosen(gymId)` once the user picks. With a single gym it
+ * calls `onChosen(undefined)` immediately and the service falls back to the default gym.
+ * Render the returned `gymGate` element somewhere in the screen.
+ */
+import React, { useCallback, useState } from 'react';
+import { SelectPicker } from '@frontend/components/overlay/SelectPicker';
+import { useGyms } from '@frontend/hooks/useGyms';
+
+type OnChosen = (gymId?: string) => void;
+
+export function useGymGate() {
+  const { data: gyms } = useGyms();
+  const [pending, setPending] = useState<{ onChosen: OnChosen } | null>(null);
+
+  const gate = useCallback(
+    (onChosen: OnChosen) => {
+      if ((gyms?.length ?? 0) >= 2) {
+        setPending({ onChosen });
+      } else {
+        onChosen(undefined);
+      }
+    },
+    [gyms]
+  );
+
+  const gymGate = (
+    <SelectPicker
+      visible={pending !== null}
+      title="Which gym?"
+      options={(gyms ?? []).map((g) => ({ label: g.name, value: g.id }))}
+      onSelect={(gymId) => {
+        const cb = pending?.onChosen;
+        setPending(null);
+        cb?.(gymId);
+      }}
+      onClose={() => setPending(null)}
+    />
+  );
+
+  return { gate, gymGate };
+}

--- a/src/frontend/hooks/useGyms.ts
+++ b/src/frontend/hooks/useGyms.ts
@@ -1,0 +1,66 @@
+/** Gym hooks - React Query queries and mutations for managing gyms (training locations). */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import * as gymService from '@backend/services/gymService';
+import { useDatabase } from '@frontend/hooks/useDatabase';
+import type { Gym } from '@shared/types/gym';
+
+/** Active (non-archived) gyms, ordered by sort order. */
+export function useGyms() {
+  const db = useDatabase();
+  return useQuery<Gym[]>({
+    queryKey: ['gyms', 'active'],
+    queryFn: () => gymService.listGyms(db, false),
+    staleTime: 60 * 1000,
+  });
+}
+
+/** All gyms including archived — for history labels and the manage-gyms screen. */
+export function useAllGyms() {
+  const db = useDatabase();
+  return useQuery<Gym[]>({
+    queryKey: ['gyms', 'all'],
+    queryFn: () => gymService.listGyms(db, true),
+    staleTime: 60 * 1000,
+  });
+}
+
+function useInvalidateGyms() {
+  const queryClient = useQueryClient();
+  return () => queryClient.invalidateQueries({ queryKey: ['gyms'] });
+}
+
+export function useCreateGym() {
+  const db = useDatabase();
+  const invalidate = useInvalidateGyms();
+  return useMutation({
+    mutationFn: (name: string) => gymService.createGym(db, name),
+    onSuccess: invalidate,
+  });
+}
+
+export function useRenameGym() {
+  const db = useDatabase();
+  const invalidate = useInvalidateGyms();
+  return useMutation({
+    mutationFn: ({ id, name }: { id: string; name: string }) => gymService.renameGym(db, id, name),
+    onSuccess: invalidate,
+  });
+}
+
+export function useArchiveGym() {
+  const db = useDatabase();
+  const invalidate = useInvalidateGyms();
+  return useMutation({
+    mutationFn: (id: string) => gymService.archiveGym(db, id),
+    onSuccess: invalidate,
+  });
+}
+
+export function useUnarchiveGym() {
+  const db = useDatabase();
+  const invalidate = useInvalidateGyms();
+  return useMutation({
+    mutationFn: (id: string) => gymService.unarchiveGym(db, id),
+    onSuccess: invalidate,
+  });
+}

--- a/src/frontend/hooks/useHistory.ts
+++ b/src/frontend/hooks/useHistory.ts
@@ -53,11 +53,15 @@ export function useWorkoutGroupDetails(workoutIds: string[]) {
   });
 }
 
-export function usePreviousSetsForExercises(exerciseIds: string[], seriesId?: string | null) {
+export function usePreviousSetsForExercises(
+  exerciseIds: string[],
+  seriesId?: string | null,
+  gymId?: string | null
+) {
   const db = useDatabase();
   return useQuery<Map<string, WorkoutSet[]>>({
-    queryKey: ['previousSets', seriesId ?? 'none', ...exerciseIds],
-    queryFn: () => workoutService.getPreviousSetsForExercises(db, exerciseIds, seriesId),
+    queryKey: ['previousSets', seriesId ?? 'none', gymId ?? 'any', ...exerciseIds],
+    queryFn: () => workoutService.getPreviousSetsForExercises(db, exerciseIds, seriesId, gymId),
     enabled: exerciseIds.length > 0 && !!seriesId,
     staleTime: 5 * 60 * 1000,
   });

--- a/src/frontend/hooks/useScheduledWorkouts.ts
+++ b/src/frontend/hooks/useScheduledWorkouts.ts
@@ -75,8 +75,8 @@ export function useStartScheduledWorkout() {
   const db = useDatabase();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ scheduledId, seriesId }: { scheduledId: string; seriesId: string }) =>
-      scheduledWorkoutService.startScheduledWorkout(db, scheduledId, seriesId),
+    mutationFn: ({ scheduledId, seriesId, gymId }: { scheduledId: string; seriesId: string; gymId?: string }) =>
+      scheduledWorkoutService.startScheduledWorkout(db, scheduledId, seriesId, gymId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['scheduledWorkouts'] });
       queryClient.invalidateQueries({ queryKey: ['activeWorkout'] });

--- a/src/frontend/hooks/useWorkout.ts
+++ b/src/frontend/hooks/useWorkout.ts
@@ -29,8 +29,8 @@ export function useStartWorkout() {
   const db = useDatabase();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ typeId, name }: { typeId: string; name?: string }) =>
-      workoutService.startWorkout(db, typeId, name),
+    mutationFn: ({ typeId, name, gymId }: { typeId: string; name?: string; gymId?: string }) =>
+      workoutService.startWorkout(db, typeId, name, null, gymId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['activeWorkout'] });
     },
@@ -163,8 +163,8 @@ export function useRepeatWorkout() {
   const db = useDatabase();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (sourceWorkoutId: string) =>
-      workoutService.repeatWorkout(db, sourceWorkoutId),
+    mutationFn: ({ sourceWorkoutId, gymId }: { sourceWorkoutId: string; gymId?: string }) =>
+      workoutService.repeatWorkout(db, sourceWorkoutId, gymId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['activeWorkout'] });
     },

--- a/src/shared/types/gym.ts
+++ b/src/shared/types/gym.ts
@@ -1,0 +1,10 @@
+/** Gym types - TypeScript interface for a training location (gym). */
+export interface Gym {
+  id: string;
+  name: string;
+  isDefault: boolean;
+  /** ISO timestamp when the gym was archived (soft-deleted), or null if active. */
+  archivedAt: string | null;
+  sortOrder: number;
+  createdAt: string;
+}

--- a/src/shared/types/workout.ts
+++ b/src/shared/types/workout.ts
@@ -31,6 +31,7 @@ export interface Workout {
   id: string;
   workoutTypeId: string;
   seriesId: string | null;
+  gymId: string | null;
   name: string | null;
   status: WorkoutStatus;
   startedAt: string;

--- a/src/shared/types/workout.ts
+++ b/src/shared/types/workout.ts
@@ -115,6 +115,8 @@ export interface WorkoutExerciseFull extends WorkoutExercise {
 export interface WorkoutSummary {
   id: string;
   seriesId: string | null;
+  gymId: string | null;
+  gymName: string | null;
   name: string | null;
   workoutTypeName: string;
   status: WorkoutStatus;


### PR DESCRIPTION
## Multiple gyms

Closes leonx03/apps-monorepo#51.

Train the same workout at multiple gyms, where each gym independently remembers its own progress and exercise setup. Gym becomes a second scoping dimension alongside `series_id` — one "main workout" (series), each session tagged with the gym it was done at.

### What's included
- **Migration v18**: new `gyms` table + `workouts.gym_id` (+ `(series_id, gym_id)` index). Seeds a default **"My Gym"** and back-fills all existing history to it, so current users stay single-gym with no behaviour change.
- **Settings → Gyms** (`GymManager`): add / rename / archive / restore gyms. The default gym is badged and cannot be archived.
- **Start gym picker** (`useGymGate`): when **≥2 active gyms** exist, starting any workout (new / repeat / scheduled) shows a "Which gym?" sheet with **nothing pre-selected**; a single gym is used implicitly.
- **Per-gym "last time" weights**: the previous-sets lookback is scoped strictly to the chosen gym — no cross-gym bleed (blank if never trained there).
- **Per-gym active alternative**: `repeatWorkout` clones the structure from *that gym's* most recent session of the series (e.g. Chest Press active at Gym A, Dumbbell Press at Gym B), falling back to the series' global latest when a gym has no history yet.
- **History**: sessions carry `gymId`/`gymName`; a gym label shows on session detail once more than one gym has existed.

### Decisions (per discussion on leonx03/apps-monorepo#51)
- Per-gym memory resolves from that gym's latest session; **structure** falls back to global latest for a new gym, **weights do not** fall back.
- Popup only with ≥2 active gyms, nothing pre-selected.
- Delete = **archive** (soft-delete); default gym not archivable.
- Gym assigned **at start only** (v1).

### Verification
- `tsc --noEmit` clean; `expo export` (full Android bundle) and both debug + release gradle builds succeed.
- Migration + per-gym queries verified against SQLite with the exact code SQL (incl. the chest-press-vs-dumbbell-per-gym scenario).
- On-device (release APK on an Android 16 emulator): migration runs, Gyms settings render, adding a 2nd gym works, the "Which gym?" popup appears on start and selecting a gym starts the workout. Details in the [verification comment](https://github.com/leonx03/apps-monorepo/issues/51#issuecomment-4826498841).

### Notes
- `schemaVersion` bumped to **18** (`src/config/app.ts`).
- Not yet exercised on-device (verified at the data layer, as they need multi-session cross-gym history): per-gym "last time" rendering and the history gym label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
