### PR TITLE
feat(splits): calendar date picker for applying a split

### DIFF
--- a/app/splits/[id].tsx
+++ b/app/splits/[id].tsx
@@ -17,7 +17,8 @@ import {
   useClearAppliedSplit,
 } from '@frontend/hooks/useSplits';
 import { ConfirmDialog } from '@frontend/components/overlay/ConfirmDialog';
-import { formatRestShort, formatPrescription } from '@shared/utils/formatting';
+import { DatePicker } from '@frontend/components/DatePicker';
+import { formatRestShort, formatPrescription, formatPlainDate } from '@shared/utils/formatting';
 import { cn } from '@frontend/lib/utils';
 import type { SplitDayFull } from '@shared/types/split';
 
@@ -79,6 +80,7 @@ export default function SplitDetailScreen() {
   const [seriesPicker, setSeriesPicker] = useState<{ mode: 'add' } | { mode: 'edit'; dayId: string } | null>(null);
   const [showApply, setShowApply] = useState(false);
   const [startDate, setStartDate] = useState(todayKey());
+  const [showDatePicker, setShowDatePicker] = useState(false);
   const [cycles, setCycles] = useState(4);
   const [applyResult, setApplyResult] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -320,13 +322,13 @@ export default function SplitDetailScreen() {
             <Text className="mt-1 text-xs text-foreground-muted">Schedules each workout day onto the agenda. Rest days are skipped.</Text>
 
             <Text className="mt-4 text-xs font-medium text-foreground-subtle">START DATE</Text>
-            <TextInput
-              value={startDate}
-              onChangeText={setStartDate}
-              placeholder="YYYY-MM-DD"
-              placeholderTextColor="rgb(115, 115, 115)"
-              className="mt-1 rounded-lg border border-background-100 px-3 py-2.5 text-foreground"
-            />
+            <Pressable
+              onPress={() => setShowDatePicker(true)}
+              className="mt-1 flex-row items-center justify-between rounded-lg border border-background-100 px-3 py-2.5"
+            >
+              <Text className="text-foreground">{formatPlainDate(startDate)}</Text>
+              <Ionicons name="calendar-outline" size={18} color="rgb(115, 115, 115)" />
+            </Pressable>
 
             <Text className="mt-4 text-xs font-medium text-foreground-subtle">CYCLES</Text>
             <View className="mt-1 flex-row items-center gap-4">
@@ -378,6 +380,13 @@ export default function SplitDetailScreen() {
         destructive
         onConfirm={handleClear}
         onCancel={() => setConfirmClear(false)}
+      />
+
+      <DatePicker
+        visible={showDatePicker}
+        value={startDate}
+        onSelect={(date) => { setStartDate(date); setShowDatePicker(false); }}
+        onClose={() => setShowDatePicker(false)}
       />
     </View>
   );

--- a/src/frontend/components/DatePicker.tsx
+++ b/src/frontend/components/DatePicker.tsx
@@ -1,0 +1,121 @@
+/** DatePicker - modal month-grid calendar for picking a single date (YYYY-MM-DD). */
+import React, { useEffect, useState } from 'react';
+import { Modal, View, Text, Pressable } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+const WEEKDAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+const pad = (n: number) => String(n).padStart(2, '0');
+const dateKey = (y: number, m: number, d: number) => `${y}-${pad(m)}-${pad(d)}`;
+
+function getDaysInMonth(year: number, month: number): number {
+  return new Date(year, month, 0).getDate();
+}
+
+/** Weekday index of the 1st, Monday-first (0 = Mon … 6 = Sun). */
+function getFirstWeekday(year: number, month: number): number {
+  const day = new Date(year, month - 1, 1).getDay();
+  return day === 0 ? 6 : day - 1;
+}
+
+function todayKey(): string {
+  const d = new Date();
+  return dateKey(d.getFullYear(), d.getMonth() + 1, d.getDate());
+}
+
+type Props = {
+  visible: boolean;
+  /** Selected date, YYYY-MM-DD. */
+  value: string;
+  onSelect: (date: string) => void;
+  onClose: () => void;
+};
+
+export function DatePicker({ visible, value, onSelect, onClose }: Props) {
+  const [vy, vm] = value.split('-').map(Number);
+  const [year, setYear] = useState(vy || new Date().getFullYear());
+  const [month, setMonth] = useState(vm || new Date().getMonth() + 1);
+
+  // Jump the calendar to the selected date's month each time it opens.
+  useEffect(() => {
+    if (!visible) return;
+    const [y, m] = value.split('-').map(Number);
+    if (y && m) { setYear(y); setMonth(m); }
+  }, [visible, value]);
+
+  const prevMonth = () => {
+    if (month === 1) { setYear((y) => y - 1); setMonth(12); }
+    else setMonth((m) => m - 1);
+  };
+  const nextMonth = () => {
+    if (month === 12) { setYear((y) => y + 1); setMonth(1); }
+    else setMonth((m) => m + 1);
+  };
+
+  const daysInMonth = getDaysInMonth(year, month);
+  const firstWeekday = getFirstWeekday(year, month);
+  const today = todayKey();
+
+  const cells: (number | null)[] = [
+    ...Array(firstWeekday).fill(null),
+    ...Array.from({ length: daysInMonth }, (_, i) => i + 1),
+  ];
+  while (cells.length % 7 !== 0) cells.push(null);
+  const rows = Array.from({ length: cells.length / 7 }, (_, r) => cells.slice(r * 7, r * 7 + 7));
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable className="flex-1 items-center justify-center bg-black/60" onPress={onClose}>
+        <Pressable className="mx-6 w-full max-w-sm rounded-2xl bg-background-50 p-4" onPress={(e) => e.stopPropagation()}>
+          {/* Month navigation */}
+          <View className="flex-row items-center justify-between mb-3">
+            <Pressable onPress={prevMonth} className="p-2 rounded-lg bg-background-100">
+              <Ionicons name="chevron-back" size={18} color="rgb(163, 163, 163)" />
+            </Pressable>
+            <Text className="text-base font-semibold text-foreground">{MONTH_NAMES[month - 1]} {year}</Text>
+            <Pressable onPress={nextMonth} className="p-2 rounded-lg bg-background-100">
+              <Ionicons name="chevron-forward" size={18} color="rgb(163, 163, 163)" />
+            </Pressable>
+          </View>
+
+          {/* Weekday headers */}
+          <View className="flex-row mb-1">
+            {WEEKDAYS.map((d) => (
+              <View key={d} className="flex-1 items-center">
+                <Text className="text-xs font-medium text-foreground-subtle">{d}</Text>
+              </View>
+            ))}
+          </View>
+
+          {/* Day grid */}
+          {rows.map((row, ri) => (
+            <View key={ri} className="flex-row mb-1">
+              {row.map((day, ci) => {
+                if (day === null) return <View key={ci} className="flex-1 aspect-square" />;
+                const key = dateKey(year, month, day);
+                const isSelected = key === value;
+                const isToday = key === today;
+                return (
+                  <Pressable
+                    key={ci}
+                    onPress={() => onSelect(key)}
+                    className="flex-1 aspect-square items-center justify-center mx-0.5 rounded-lg"
+                    style={isSelected ? { backgroundColor: 'rgb(52, 211, 153)' } : isToday ? { backgroundColor: 'rgba(52, 211, 153, 0.15)' } : undefined}
+                  >
+                    <Text className={`text-sm font-medium ${isSelected ? 'text-background' : isToday ? 'text-primary' : 'text-foreground'}`}>
+                      {day}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+          ))}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}

--- a/src/shared/utils/formatting.ts
+++ b/src/shared/utils/formatting.ts
@@ -66,6 +66,13 @@ export function formatTimerDisplay(seconds: number): string {
   return `${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
 }
 
+/** Format a plain YYYY-MM-DD date (no time/UTC) for display, e.g. "Mon, Jun 29 2026". */
+export function formatPlainDate(dateStr: string): string {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  if (!y || !m || !d) return dateStr;
+  return format(new Date(y, m - 1, d), 'EEE, MMM d yyyy');
+}
+
 /** Short rest display, e.g. 45 -> "45s", 120 -> "2 min", 240 -> "4 min". */
 export function formatRestShort(seconds: number): string {
   if (seconds < 60) return `${seconds}s`;


### PR DESCRIPTION
Quick follow-up to #33: the "Start date" field in the Apply Split modal was a free-text `YYYY-MM-DD` input. Replace it with a tappable field that opens an in-app calendar.

## Changes
- New reusable `DatePicker` component (`src/frontend/components/DatePicker.tsx`) — month-grid calendar styled like the Agenda tab (Monday-first, prev/next month nav, selected + today highlight). Pure JS, no native dependency.
- `formatPlainDate` helper in `formatting.ts` for the field label (e.g. "Mon, Jun 29 2026").
- Wire it into `app/splits/[id].tsx`: the start-date row is now a Pressable that opens the picker.

## Verification
- `tsc --noEmit` clean.
- Verified on a real device via MCP: field shows the formatted date + calendar icon, tapping opens the calendar over the Apply modal, month nav works, selecting a day updates the field and closes the calendar while keeping the modal open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)