### PR TITLE
feat(bodyweight): weekly average on home & profile

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -6,8 +6,9 @@ import { Ionicons } from '@expo/vector-icons';
 import * as progressService from '@backend/services/progressService';
 import { useDatabase } from '@frontend/hooks/useDatabase';
 import { useSettingsStore } from '@backend/store/settingsStore';
-import { useBodyWeightTrend } from '@frontend/hooks/useBodyWeight';
+import { useBodyWeightTrend, useBodyWeightWeeklyAverages } from '@frontend/hooks/useBodyWeight';
 import { WeightSparkline } from '@frontend/components/profile/WeightSparkline';
+import { WeeklyAverages } from '@frontend/components/profile/WeeklyAverages';
 import { MUSCLE_GROUP_LABELS } from '@shared/constants/muscleGroups';
 import type { MuscleGroup } from '@shared/types/exercise';
 
@@ -65,6 +66,7 @@ export default function HomeScreen() {
   });
 
   const { data: weightTrend } = useBodyWeightTrend(30);
+  const { data: weeklyAverages } = useBodyWeightWeeklyAverages(8);
 
   const { data: weeklyPRCount } = useQuery({
     queryKey: ['weeklyPRCount', weekOffset],
@@ -164,6 +166,11 @@ export default function HomeScreen() {
           <View className="mx-4 mt-3 rounded-xl bg-background-50 p-4">
             <Text className="text-sm font-medium text-foreground-muted mb-3">Body Weight</Text>
             <WeightSparkline entries={weightTrend} units={units} />
+            {weeklyAverages && weeklyAverages.length > 0 && (
+              <View className="mt-4 border-t border-background-100 pt-4">
+                <WeeklyAverages weeks={weeklyAverages} units={units} />
+              </View>
+            )}
           </View>
         )}
       </ScrollView>

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -6,8 +6,9 @@ import Constants from 'expo-constants';
 import * as Linking from 'expo-linking';
 import { useSettingsStore } from '@backend/store/settingsStore';
 import { useDatabase } from '@frontend/hooks/useDatabase';
-import { useBodyWeightHistory, useLogBodyWeight, useDeleteBodyWeight } from '@frontend/hooks/useBodyWeight';
+import { useBodyWeightHistory, useLogBodyWeight, useDeleteBodyWeight, useBodyWeightWeeklyAverages } from '@frontend/hooks/useBodyWeight';
 import { WeightSparkline } from '@frontend/components/profile/WeightSparkline';
+import { WeeklyAverages } from '@frontend/components/profile/WeeklyAverages';
 import { GymManager } from '@frontend/components/profile/GymManager';
 import { SelectPicker } from '@frontend/components/overlay/SelectPicker';
 import { WeightHistorySheet } from '@frontend/components/overlay/WeightHistorySheet';
@@ -45,6 +46,7 @@ export default function ProfileScreen() {
   const [showWeightHistory, setShowWeightHistory] = useState(false);
 
   const { data: weightHistory } = useBodyWeightHistory();
+  const { data: weeklyAverages } = useBodyWeightWeeklyAverages(8);
   const logWeight = useLogBodyWeight();
   const deleteWeight = useDeleteBodyWeight();
 
@@ -119,6 +121,13 @@ export default function ProfileScreen() {
           {weightHistory && weightHistory.length > 0 && (
             <View className="mb-3">
               <WeightSparkline entries={weightHistory.slice(0, 30)} units={units} />
+            </View>
+          )}
+
+          {/* Weekly averages */}
+          {weeklyAverages && weeklyAverages.length > 0 && (
+            <View className="mb-3 border-t border-background-100 pt-3">
+              <WeeklyAverages weeks={weeklyAverages} units={units} />
             </View>
           )}
 

--- a/src/backend/models/bodyWeight.ts
+++ b/src/backend/models/bodyWeight.ts
@@ -1,7 +1,7 @@
 /** Body weight model - CRUD operations for the body_weight_entries table. */
 import type * as SQLite from 'expo-sqlite';
 import * as Crypto from 'expo-crypto';
-import type { BodyWeightEntry } from '@shared/types/bodyWeight';
+import type { BodyWeightEntry, WeeklyAverageWeight } from '@shared/types/bodyWeight';
 
 interface BodyWeightRow {
   id: string;
@@ -34,6 +34,40 @@ export async function getRecent(db: SQLite.SQLiteDatabase, limit: number): Promi
     limit
   );
   return rows.map(mapRow);
+}
+
+interface WeeklyAverageRow {
+  week_start: string;
+  avg_weight_kg: number;
+  entry_count: number;
+}
+
+/**
+ * Average body weight per week, most recent week first. Weeks are Monday-anchored: the
+ * `week_start` is computed as the Monday on or before each entry's date, so grouping and the
+ * returned label are the same value (avoids the year-boundary quirks of strftime('%W')).
+ * `%w` is 0=Sunday..6=Saturday, so `(%w + 6) % 7` = days since Monday.
+ */
+export async function getWeeklyAverages(
+  db: SQLite.SQLiteDatabase,
+  limit?: number
+): Promise<WeeklyAverageWeight[]> {
+  const sql = `SELECT
+       date(date, '-' || ((CAST(strftime('%w', date) AS INTEGER) + 6) % 7) || ' days') AS week_start,
+       AVG(weight_kg) AS avg_weight_kg,
+       COUNT(*)       AS entry_count
+     FROM body_weight_entries
+     GROUP BY week_start
+     ORDER BY week_start DESC`;
+  const rows =
+    limit != null
+      ? await db.getAllAsync<WeeklyAverageRow>(`${sql} LIMIT ?`, limit)
+      : await db.getAllAsync<WeeklyAverageRow>(sql);
+  return rows.map((row) => ({
+    weekStart: row.week_start,
+    avgWeightKg: row.avg_weight_kg,
+    entryCount: row.entry_count,
+  }));
 }
 
 export async function getByDate(db: SQLite.SQLiteDatabase, date: string): Promise<BodyWeightEntry | null> {

--- a/src/backend/services/bodyWeightService.ts
+++ b/src/backend/services/bodyWeightService.ts
@@ -1,7 +1,7 @@
 /** Body weight service - business logic for logging and retrieving body weight entries. */
 import type * as SQLite from 'expo-sqlite';
 import * as bodyWeightModel from '@backend/models/bodyWeight';
-import type { BodyWeightEntry } from '@shared/types/bodyWeight';
+import type { BodyWeightEntry, WeeklyAverageWeight } from '@shared/types/bodyWeight';
 
 export async function logWeight(
   db: SQLite.SQLiteDatabase,
@@ -18,6 +18,13 @@ export async function getHistory(db: SQLite.SQLiteDatabase): Promise<BodyWeightE
 
 export async function getRecentTrend(db: SQLite.SQLiteDatabase, count: number): Promise<BodyWeightEntry[]> {
   return bodyWeightModel.getRecent(db, count);
+}
+
+export async function getWeeklyAverages(
+  db: SQLite.SQLiteDatabase,
+  limit?: number
+): Promise<WeeklyAverageWeight[]> {
+  return bodyWeightModel.getWeeklyAverages(db, limit);
 }
 
 export async function deleteEntry(db: SQLite.SQLiteDatabase, id: string): Promise<void> {

--- a/src/frontend/components/profile/WeeklyAverages.tsx
+++ b/src/frontend/components/profile/WeeklyAverages.tsx
@@ -1,0 +1,66 @@
+/** WeeklyAverages - the current week's average body weight (with week-over-week delta) plus recent weeks. */
+import React from 'react';
+import { View, Text } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { formatWeight, formatWeekRange } from '@shared/utils/formatting';
+import type { WeeklyAverageWeight } from '@shared/types/bodyWeight';
+import type { UnitSystem } from '@shared/types/settings';
+
+type WeeklyAveragesProps = {
+  weeks: WeeklyAverageWeight[]; // most recent week first
+  units: UnitSystem;
+};
+
+export function WeeklyAverages({ weeks, units }: WeeklyAveragesProps) {
+  if (weeks.length === 0) return null;
+
+  const [latest, ...rest] = weeks;
+  const previous = rest[0];
+  const deltaKg = previous ? latest.avgWeightKg - previous.avgWeightKg : null;
+  // A change under 0.05 kg rounds to "0.0" at one decimal — treat it as flat.
+  const isFlat = deltaKg != null && Math.abs(deltaKg) < 0.05;
+
+  return (
+    <View>
+      <Text className="text-xs font-medium text-foreground-muted mb-2">Weekly average</Text>
+
+      {/* Current (latest) week headline + week-over-week change */}
+      <View className="flex-row items-end justify-between">
+        <View>
+          <Text className="text-xs text-foreground-subtle">{formatWeekRange(latest.weekStart)}</Text>
+          <Text className="text-2xl font-bold text-foreground">{formatWeight(latest.avgWeightKg, units)}</Text>
+          <Text className="text-xs text-foreground-subtle">
+            {latest.entryCount} {latest.entryCount === 1 ? 'entry' : 'entries'}
+          </Text>
+        </View>
+
+        {deltaKg != null && (
+          <View className="flex-row items-center gap-1">
+            <Ionicons
+              name={isFlat ? 'remove' : deltaKg > 0 ? 'arrow-up' : 'arrow-down'}
+              size={14}
+              color="rgb(163, 163, 163)"
+            />
+            <Text className="text-sm text-foreground-muted">
+              {isFlat ? 'No change' : `${formatWeight(Math.abs(deltaKg), units)} vs last`}
+            </Text>
+          </View>
+        )}
+      </View>
+
+      {/* Prior weeks, each with its own average */}
+      {rest.length > 0 && (
+        <View className="mt-3 gap-1.5">
+          {rest.map((week) => (
+            <View key={week.weekStart} className="flex-row items-center justify-between">
+              <Text className="text-sm text-foreground">{formatWeekRange(week.weekStart)}</Text>
+              <Text className="text-sm font-semibold text-foreground">
+                {formatWeight(week.avgWeightKg, units)}
+              </Text>
+            </View>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}

--- a/src/frontend/hooks/useBodyWeight.ts
+++ b/src/frontend/hooks/useBodyWeight.ts
@@ -19,6 +19,14 @@ export function useBodyWeightTrend(count: number = 30) {
   });
 }
 
+export function useBodyWeightWeeklyAverages(limit?: number) {
+  const db = useDatabase();
+  return useQuery({
+    queryKey: ['bodyWeight', 'weeklyAverages', limit ?? null],
+    queryFn: () => bodyWeightService.getWeeklyAverages(db, limit),
+  });
+}
+
 export function useLogBodyWeight() {
   const db = useDatabase();
   const queryClient = useQueryClient();

--- a/src/shared/types/bodyWeight.ts
+++ b/src/shared/types/bodyWeight.ts
@@ -6,3 +6,10 @@ export interface BodyWeightEntry {
   notes: string | null;
   createdAt: string;
 }
+
+/** A week's average body weight, aggregated from the daily entries in that week. */
+export interface WeeklyAverageWeight {
+  weekStart: string; // YYYY-MM-DD, the Monday of the week
+  avgWeightKg: number;
+  entryCount: number;
+}

--- a/src/shared/utils/formatting.ts
+++ b/src/shared/utils/formatting.ts
@@ -73,6 +73,33 @@ export function formatPlainDate(dateStr: string): string {
   return format(new Date(y, m - 1, d), 'EEE, MMM d yyyy');
 }
 
+/** YYYY-MM-DD of the Monday on or before the given local date. */
+function localMonday(d: Date): string {
+  const daysSinceMonday = (d.getDay() + 6) % 7; // getDay: 0=Sun..6=Sat
+  const monday = new Date(d.getFullYear(), d.getMonth(), d.getDate() - daysSinceMonday);
+  const m = String(monday.getMonth() + 1).padStart(2, '0');
+  const day = String(monday.getDate()).padStart(2, '0');
+  return `${monday.getFullYear()}-${m}-${day}`;
+}
+
+/**
+ * Label a Monday-anchored week from its start date (YYYY-MM-DD): "This week", "Last week",
+ * or a range like "Jun 29 – Jul 5" (or "Jun 2 – 8" when both ends share a month).
+ */
+export function formatWeekRange(weekStart: string): string {
+  const [y, m, d] = weekStart.split('-').map(Number);
+  if (!y || !m || !d) return weekStart;
+  const now = new Date();
+  if (weekStart === localMonday(now)) return 'This week';
+  const lastWeek = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7);
+  if (weekStart === localMonday(lastWeek)) return 'Last week';
+  const monday = new Date(y, m - 1, d);
+  const sunday = new Date(y, m - 1, d + 6); // JS normalizes month overflow
+  const startFmt = format(monday, 'MMM d');
+  const endFmt = format(sunday, monday.getMonth() === sunday.getMonth() ? 'd' : 'MMM d');
+  return `${startFmt} – ${endFmt}`;
+}
+
 /** Short rest display, e.g. 45 -> "45s", 120 -> "2 min", 240 -> "4 min". */
 export function formatRestShort(seconds: number): string {
   if (seconds < 60) return `${seconds}s`;


### PR DESCRIPTION
## Summary
Improves the existing body-weight tracking by turning the daily entries into **weekly averages** — every week produces its own average, shown on both the **Home dashboard** and the **Profile** Body Weight cards.

- **Current week's average** as a headline, with a **week-over-week delta** (e.g. "↓ 1 kg vs last") and the entry count.
- A list of **recent weeks**, each with its own average and a friendly label ("This week" / "Last week" / "Jun 8 – 14").

## Implementation
- `bodyWeight` model: `getWeeklyAverages()` — SQL `AVG(weight_kg)` grouped by the **Monday on/before each entry's date** (`date(date, '-' || ((strftime('%w')+6)%7) || ' days')`), which sidesteps the year-boundary quirks of `strftime('%W')`.
- `bodyWeightService.getWeeklyAverages` + `useBodyWeightWeeklyAverages` hook (keyed under the `['bodyWeight']` prefix, so it auto-refreshes on log/delete).
- New `WeeklyAverages` component + `formatWeekRange` formatting helper.
- Wired into `app/(tabs)/index.tsx` (Home) and `app/(tabs)/profile.tsx`.

No DB migration — this is a read-only aggregation of existing data.

## Testing
- **SQL replay** (`sqlite3`): verified Monday-anchored grouping, Sundays land in the correct week, and a cross-year week (Dec 29 2025 → Jan 4 2026) groups as one.
- **`tsc --noEmit`**: clean.
- **E2E on Android emulator** (release APK): logged entries across 4 different weeks (via clock-shifting) — confirmed each week shows its own average, within-week averaging works (2 entries → mean of 82 kg), the week-over-week delta is correct, labels resolve, and it renders on both Home and Profile with no crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)