### PR TITLE
feat(food): macro & food tracker with one-tap saved meals

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -18,6 +18,12 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
+        name="food"
+        options={{
+          title: 'Food',
+        }}
+      />
+      <Tabs.Screen
         name="workouts"
         options={{
           title: 'Workouts',

--- a/app/(tabs)/food.tsx
+++ b/app/(tabs)/food.tsx
@@ -1,0 +1,300 @@
+/** Food screen - daily macro log: totals, remaining vs targets, one-tap quick-add, and the day's entries. */
+import React, { useState, useMemo } from 'react';
+import { View, Text, ScrollView, Pressable } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { useDatabase } from '@frontend/hooks/useDatabase';
+import { useSettingsStore } from '@backend/store/settingsStore';
+import {
+  useFoodDay,
+  useSavedMeals,
+  useFoods,
+  useLogFood,
+  useLogSavedMeal,
+  useUpdateLogQuantity,
+  useDeleteLogEntry,
+} from '@frontend/hooks/useFood';
+import { MacroProgressBar } from '@frontend/components/food/MacroProgressBar';
+import { MacroChips } from '@frontend/components/food/MacroChips';
+import { FoodPickerSheet } from '@frontend/components/food/FoodPickerSheet';
+import { TargetsSheet } from '@frontend/components/food/TargetsSheet';
+import { EditQuantitySheet } from '@frontend/components/food/EditQuantitySheet';
+import { ConfirmDialog } from '@frontend/components/overlay/ConfirmDialog';
+import { MACRO_COLORS, MACRO_OVER_COLOR } from '@shared/constants/macros';
+import { formatCalories, formatGrams, formatPlainDate } from '@shared/utils/formatting';
+import type { FoodLogEntry } from '@shared/types/food';
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0');
+}
+function todayStr(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+function shiftDate(dateStr: string, days: number): string {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  const dt = new Date(y, m - 1, d + days);
+  return `${dt.getFullYear()}-${pad(dt.getMonth() + 1)}-${pad(dt.getDate())}`;
+}
+function dayLabel(dateStr: string): string {
+  const today = todayStr();
+  if (dateStr === today) return 'Today';
+  if (dateStr === shiftDate(today, -1)) return 'Yesterday';
+  if (dateStr === shiftDate(today, 1)) return 'Tomorrow';
+  return formatPlainDate(dateStr);
+}
+
+export default function FoodScreen() {
+  const db = useDatabase();
+  const router = useRouter();
+  const { dailyCalorieTarget, dailyProteinTarget, updateMacroTargets } = useSettingsStore();
+
+  const [date, setDate] = useState(todayStr());
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [targetsOpen, setTargetsOpen] = useState(false);
+  const [editEntry, setEditEntry] = useState<FoodLogEntry | null>(null);
+  const [deleteEntry, setDeleteEntry] = useState<FoodLogEntry | null>(null);
+
+  const { data: day } = useFoodDay(date);
+  const { data: meals } = useSavedMeals();
+  const { data: foods } = useFoods();
+
+  const logFood = useLogFood();
+  const logMeal = useLogSavedMeal();
+  const updateQuantity = useUpdateLogQuantity();
+  const deleteLog = useDeleteLogEntry();
+
+  const totals = day?.totals ?? { calories: 0, proteinG: 0, carbsG: 0, fatG: 0, entryCount: 0 };
+  const entries = day?.entries ?? [];
+
+  const calRemaining = Math.round(dailyCalorieTarget - totals.calories);
+  const proRemaining = Math.round(dailyProteinTarget - totals.proteinG);
+
+  const isToday = date === todayStr();
+
+  const summaryTiles = useMemo(
+    () => [
+      { key: 'cal', label: 'Calories left', remaining: calRemaining, unit: 'kcal', distinct: false },
+      { key: 'pro', label: 'Protein left', remaining: proRemaining, unit: 'g', distinct: true },
+    ],
+    [calRemaining, proRemaining]
+  );
+
+  return (
+    <View className="flex-1 bg-background">
+      <ScrollView className="flex-1" contentContainerClassName="pb-[100px]">
+        {/* Header */}
+        <View className="flex-row items-center justify-between px-4 pt-4 pb-2">
+          <Text className="text-2xl font-bold text-foreground">Nutrition</Text>
+          <Pressable onPress={() => setTargetsOpen(true)} className="rounded-lg bg-background-50 px-3 py-2 flex-row items-center gap-1">
+            <Ionicons name="options-outline" size={16} color="rgb(52, 211, 153)" />
+            <Text className="text-sm text-primary">Targets</Text>
+          </Pressable>
+        </View>
+
+        {/* Date selector */}
+        <View className="flex-row items-center justify-between px-4 mt-1">
+          <Pressable onPress={() => setDate((d) => shiftDate(d, -1))} className="rounded-lg bg-background-50 p-2">
+            <Ionicons name="chevron-back" size={18} color="rgb(163, 163, 163)" />
+          </Pressable>
+          <Text className="flex-1 text-center text-sm font-medium text-foreground">{dayLabel(date)}</Text>
+          <Pressable
+            onPress={() => setDate((d) => shiftDate(d, 1))}
+            className="rounded-lg bg-background-50 p-2"
+            disabled={isToday}
+          >
+            <Ionicons name="chevron-forward" size={18} color={isToday ? 'rgb(64, 64, 64)' : 'rgb(163, 163, 163)'} />
+          </Pressable>
+        </View>
+
+        {/* Remaining tiles */}
+        <View className="flex-row px-4 mt-3 gap-3">
+          {summaryTiles.map((t) => {
+            const over = t.remaining < 0;
+            return (
+              <View
+                key={t.key}
+                className={`flex-1 rounded-xl p-4 ${t.distinct ? 'bg-primary/10 border border-primary/40' : 'bg-background-50'}`}
+              >
+                <Text className="text-xs text-foreground-muted">{t.label}</Text>
+                <Text
+                  className="mt-1 text-3xl font-bold"
+                  style={{ color: t.distinct ? MACRO_COLORS.protein : 'rgb(250,250,250)' }}
+                >
+                  {over ? `+${Math.abs(t.remaining)}` : t.remaining}
+                </Text>
+                <Text className="text-xs" style={{ color: over ? MACRO_OVER_COLOR : 'rgb(115,115,115)' }}>
+                  {over ? `${t.unit} over` : `${t.unit} remaining`}
+                </Text>
+              </View>
+            );
+          })}
+        </View>
+
+        {/* Progress bars */}
+        <View className="mx-4 mt-3 rounded-xl bg-background-50 p-4 gap-4">
+          <MacroProgressBar
+            label="Calories"
+            value={totals.calories}
+            target={dailyCalorieTarget}
+            unit="kcal"
+            color={MACRO_COLORS.calories}
+          />
+          <MacroProgressBar
+            label="Protein"
+            value={totals.proteinG}
+            target={dailyProteinTarget}
+            unit="g"
+            color={MACRO_COLORS.protein}
+          />
+          <View className="border-t border-background-100 pt-3">
+            <MacroChips totals={totals} />
+          </View>
+        </View>
+
+        {/* Quick-add saved meals */}
+        <View className="mt-4">
+          <View className="flex-row items-center justify-between px-4 mb-2">
+            <Text className="text-sm font-medium text-foreground-muted">Quick add</Text>
+            <Pressable onPress={() => router.push('/food/meals')}>
+              <Text className="text-xs text-primary">Manage meals</Text>
+            </Pressable>
+          </View>
+          {meals && meals.length > 0 ? (
+            <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerClassName="px-4 gap-2">
+              {meals.map((meal) => (
+                <Pressable
+                  key={meal.id}
+                  onPress={() => logMeal.mutate({ date, savedMealId: meal.id })}
+                  className="w-40 rounded-xl bg-background-50 p-3 border border-background-100"
+                >
+                  <Text className="text-sm font-semibold text-foreground" numberOfLines={1}>
+                    {meal.name}
+                  </Text>
+                  <Text className="mt-1 text-xs text-foreground-subtle">{formatCalories(meal.totals.calories)}</Text>
+                  <Text className="text-xs" style={{ color: MACRO_COLORS.protein }}>
+                    P {formatGrams(meal.totals.proteinG)}
+                  </Text>
+                  <View className="mt-2 flex-row items-center gap-1">
+                    <Ionicons name="add-circle" size={16} color="rgb(52, 211, 153)" />
+                    <Text className="text-xs text-primary">Log 1 serving</Text>
+                  </View>
+                </Pressable>
+              ))}
+            </ScrollView>
+          ) : (
+            <Pressable onPress={() => router.push('/food/meals')} className="mx-4 rounded-xl bg-background-50 p-4 items-center">
+              <Text className="text-sm text-foreground-subtle">No saved meals yet — create one for one-tap logging</Text>
+            </Pressable>
+          )}
+        </View>
+
+        {/* Add food button */}
+        <Pressable
+          onPress={() => setPickerOpen(true)}
+          className="mx-4 mt-4 rounded-xl bg-background-50 py-3 flex-row items-center justify-center gap-2"
+        >
+          <Ionicons name="add" size={18} color="rgb(52, 211, 153)" />
+          <Text className="text-sm font-semibold text-primary">Add a food</Text>
+        </Pressable>
+
+        {/* Log entries */}
+        <View className="mx-4 mt-4">
+          <Text className="text-sm font-medium text-foreground-muted mb-2">
+            {dayLabel(date)}'s log{entries.length > 0 ? ` (${entries.length})` : ''}
+          </Text>
+          {entries.length === 0 ? (
+            <Text className="text-sm text-foreground-subtle text-center py-6">Nothing logged yet</Text>
+          ) : (
+            <View className="gap-2">
+              {entries.map((entry) => (
+                <View
+                  key={entry.id}
+                  className="flex-row items-center justify-between rounded-xl bg-background-50 px-4 py-3"
+                >
+                  <Pressable className="flex-1 pr-3" onPress={() => setEditEntry(entry)}>
+                    <View className="flex-row items-center gap-2">
+                      <Ionicons
+                        name={entry.entryType === 'meal' ? 'restaurant-outline' : 'nutrition-outline'}
+                        size={14}
+                        color="rgb(115, 115, 115)"
+                      />
+                      <Text className="text-base text-foreground" numberOfLines={1}>
+                        {entry.name}
+                      </Text>
+                    </View>
+                    <Text className="mt-0.5 text-xs text-foreground-subtle">
+                      {formatCalories(entry.calories)} · P {formatGrams(entry.proteinG)} · C{' '}
+                      {formatGrams(entry.carbsG)} · F {formatGrams(entry.fatG)}
+                    </Text>
+                  </Pressable>
+                  <Pressable onPress={() => setDeleteEntry(entry)} className="p-1.5">
+                    <Ionicons name="trash-outline" size={16} color="rgb(163, 163, 163)" />
+                  </Pressable>
+                </View>
+              ))}
+            </View>
+          )}
+        </View>
+
+        {/* Manage foods link */}
+        <Pressable
+          onPress={() => router.push('/food/foods')}
+          className="mx-4 mt-4 flex-row items-center justify-between rounded-xl bg-background-50 px-4 py-3"
+        >
+          <View className="flex-row items-center gap-2">
+            <Ionicons name="list-outline" size={18} color="rgb(163, 163, 163)" />
+            <Text className="text-sm text-foreground">Manage foods</Text>
+          </View>
+          <Ionicons name="chevron-forward" size={16} color="rgb(163, 163, 163)" />
+        </Pressable>
+
+        {(logFood.error || logMeal.error) && (
+          <Text className="mx-4 mt-3 text-xs text-destructive">
+            {(logFood.error as Error)?.message ?? (logMeal.error as Error)?.message}
+          </Text>
+        )}
+      </ScrollView>
+
+      {/* Overlays */}
+      <FoodPickerSheet
+        visible={pickerOpen}
+        foods={foods ?? []}
+        title="Log a food"
+        confirmLabel="Log"
+        onPick={(food, quantity) => logFood.mutate({ date, foodId: food.id, quantity })}
+        onClose={() => setPickerOpen(false)}
+      />
+
+      <TargetsSheet
+        visible={targetsOpen}
+        calorieTarget={dailyCalorieTarget}
+        proteinTarget={dailyProteinTarget}
+        onSave={(cals, pro) => updateMacroTargets(db, { dailyCalorieTarget: cals, dailyProteinTarget: pro })}
+        onClose={() => setTargetsOpen(false)}
+      />
+
+      <EditQuantitySheet
+        visible={!!editEntry}
+        entry={editEntry}
+        onSave={(quantity) => {
+          if (editEntry) updateQuantity.mutate({ id: editEntry.id, quantity });
+        }}
+        onClose={() => setEditEntry(null)}
+      />
+
+      <ConfirmDialog
+        visible={!!deleteEntry}
+        title="Delete entry"
+        message={`Remove "${deleteEntry?.name}" from ${dayLabel(date).toLowerCase()}'s log?`}
+        confirmLabel="Delete"
+        destructive
+        onConfirm={() => {
+          if (deleteEntry) deleteLog.mutate(deleteEntry.id);
+          setDeleteEntry(null);
+        }}
+        onCancel={() => setDeleteEntry(null)}
+      />
+    </View>
+  );
+}

--- a/app/food/_layout.tsx
+++ b/app/food/_layout.tsx
@@ -1,0 +1,15 @@
+/** Food layout - Stack navigator wrapper for the food management screens. */
+import React from 'react';
+import { Stack } from 'expo-router';
+
+export default function FoodLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: 'rgb(10, 10, 15)' },
+        animation: 'slide_from_right',
+      }}
+    />
+  );
+}

--- a/app/food/foods.tsx
+++ b/app/food/foods.tsx
@@ -1,0 +1,101 @@
+/** Foods library screen - list, create, edit, and archive foods. */
+import React, { useState } from 'react';
+import { View, Text, Pressable, FlatList } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { useFoods, useCreateFood, useUpdateFood, useArchiveFood } from '@frontend/hooks/useFood';
+import { FoodFormSheet } from '@frontend/components/food/FoodFormSheet';
+import { ConfirmDialog } from '@frontend/components/overlay/ConfirmDialog';
+import { formatCalories, formatGrams, formatAmount } from '@shared/utils/formatting';
+import { MACRO_COLORS } from '@shared/constants/macros';
+import type { FoodItem, FoodItemInput } from '@shared/types/food';
+
+export default function FoodsScreen() {
+  const router = useRouter();
+  const { data: foods } = useFoods();
+  const createFood = useCreateFood();
+  const updateFood = useUpdateFood();
+  const archiveFood = useArchiveFood();
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<FoodItem | null>(null);
+  const [archiveTarget, setArchiveTarget] = useState<FoodItem | null>(null);
+
+  const handleSave = (input: FoodItemInput) => {
+    if (editing) updateFood.mutate({ id: editing.id, input });
+    else createFood.mutate(input);
+  };
+
+  return (
+    <View className="flex-1 bg-background">
+      {/* Header */}
+      <View className="flex-row items-center justify-between border-b border-background-100 px-4 pb-3 pt-4">
+        <Pressable onPress={() => router.back()} className="flex-row items-center gap-1 py-1">
+          <Ionicons name="chevron-back" size={20} color="rgb(163, 163, 163)" />
+          <Text className="text-base text-foreground-muted">Back</Text>
+        </Pressable>
+        <Text className="text-lg font-bold text-foreground">Foods</Text>
+        <Pressable
+          onPress={() => {
+            setEditing(null);
+            setFormOpen(true);
+          }}
+          className="py-1"
+        >
+          <Ionicons name="add" size={24} color="rgb(52, 211, 153)" />
+        </Pressable>
+      </View>
+
+      <FlatList
+        data={foods}
+        keyExtractor={(item) => item.id}
+        contentContainerClassName="px-4 py-4 pb-10"
+        ListEmptyComponent={
+          <Text className="text-sm text-foreground-subtle text-center py-10">
+            No foods yet. Tap + to add one.
+          </Text>
+        }
+        renderItem={({ item }) => (
+          <View className="flex-row items-center justify-between rounded-xl bg-background-50 px-4 py-3 mb-2">
+            <Pressable
+              className="flex-1 pr-3"
+              onPress={() => {
+                setEditing(item);
+                setFormOpen(true);
+              }}
+            >
+              <Text className="text-base text-foreground">{item.name}</Text>
+              <Text className="text-xs text-foreground-subtle">
+                per {formatAmount(item.servingSize, item.servingUnit)} · {formatCalories(item.calories)} ·{' '}
+                <Text style={{ color: MACRO_COLORS.protein }}>P {formatGrams(item.proteinG)}</Text>
+              </Text>
+            </Pressable>
+            <Pressable onPress={() => setArchiveTarget(item)} className="p-1.5">
+              <Ionicons name="trash-outline" size={16} color="rgb(163, 163, 163)" />
+            </Pressable>
+          </View>
+        )}
+      />
+
+      <FoodFormSheet
+        visible={formOpen}
+        food={editing}
+        onSave={handleSave}
+        onClose={() => setFormOpen(false)}
+      />
+
+      <ConfirmDialog
+        visible={!!archiveTarget}
+        title="Remove food"
+        message={`Remove "${archiveTarget?.name}"? Past log entries and meals that use it are kept.`}
+        confirmLabel="Remove"
+        destructive
+        onConfirm={() => {
+          if (archiveTarget) archiveFood.mutate(archiveTarget.id);
+          setArchiveTarget(null);
+        }}
+        onCancel={() => setArchiveTarget(null)}
+      />
+    </View>
+  );
+}

--- a/app/food/meals.tsx
+++ b/app/food/meals.tsx
@@ -1,0 +1,120 @@
+/** Saved meals library screen - list, create, edit, and archive reusable meals. */
+import React, { useState } from 'react';
+import { View, Text, Pressable, FlatList } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import {
+  useSavedMeals,
+  useSavedMeal,
+  useFoods,
+  useCreateSavedMeal,
+  useUpdateSavedMeal,
+  useArchiveSavedMeal,
+} from '@frontend/hooks/useFood';
+import { MealComposerSheet } from '@frontend/components/food/MealComposerSheet';
+import { ConfirmDialog } from '@frontend/components/overlay/ConfirmDialog';
+import { formatCalories, formatGrams } from '@shared/utils/formatting';
+import { MACRO_COLORS } from '@shared/constants/macros';
+import type { SavedMealInput, SavedMealWithTotals } from '@shared/types/food';
+
+export default function MealsScreen() {
+  const router = useRouter();
+  const { data: meals } = useSavedMeals();
+  const { data: foods } = useFoods();
+  const createMeal = useCreateSavedMeal();
+  const updateMeal = useUpdateSavedMeal();
+  const archiveMeal = useArchiveSavedMeal();
+
+  const [composerOpen, setComposerOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [archiveTarget, setArchiveTarget] = useState<SavedMealWithTotals | null>(null);
+
+  const { data: editingMeal } = useSavedMeal(editingId);
+
+  const handleSave = (input: SavedMealInput) => {
+    if (editingId) updateMeal.mutate({ id: editingId, input });
+    else createMeal.mutate(input);
+  };
+
+  return (
+    <View className="flex-1 bg-background">
+      {/* Header */}
+      <View className="flex-row items-center justify-between border-b border-background-100 px-4 pb-3 pt-4">
+        <Pressable onPress={() => router.back()} className="flex-row items-center gap-1 py-1">
+          <Ionicons name="chevron-back" size={20} color="rgb(163, 163, 163)" />
+          <Text className="text-base text-foreground-muted">Back</Text>
+        </Pressable>
+        <Text className="text-lg font-bold text-foreground">Saved Meals</Text>
+        <Pressable
+          onPress={() => {
+            setEditingId(null);
+            setComposerOpen(true);
+          }}
+          className="py-1"
+        >
+          <Ionicons name="add" size={24} color="rgb(52, 211, 153)" />
+        </Pressable>
+      </View>
+
+      <FlatList
+        data={meals}
+        keyExtractor={(item) => item.id}
+        contentContainerClassName="px-4 py-4 pb-10"
+        ListEmptyComponent={
+          <Text className="text-sm text-foreground-subtle text-center py-10">
+            No saved meals yet. Tap + to build one for one-tap logging.
+          </Text>
+        }
+        renderItem={({ item }) => (
+          <View className="flex-row items-center justify-between rounded-xl bg-background-50 px-4 py-3 mb-2">
+            <Pressable
+              className="flex-1 pr-3"
+              onPress={() => {
+                setEditingId(item.id);
+                setComposerOpen(true);
+              }}
+            >
+              <View className="flex-row items-center gap-2">
+                <Text className="text-base text-foreground">{item.name}</Text>
+                <View className="rounded bg-background-100 px-1.5 py-0.5">
+                  <Text className="text-[10px] text-foreground-subtle">
+                    {item.kind === 'composed' ? 'recipe' : 'manual'}
+                  </Text>
+                </View>
+              </View>
+              <Text className="text-xs text-foreground-subtle">
+                {formatCalories(item.totals.calories)} ·{' '}
+                <Text style={{ color: MACRO_COLORS.protein }}>P {formatGrams(item.totals.proteinG)}</Text> · C{' '}
+                {formatGrams(item.totals.carbsG)} · F {formatGrams(item.totals.fatG)}
+              </Text>
+            </Pressable>
+            <Pressable onPress={() => setArchiveTarget(item)} className="p-1.5">
+              <Ionicons name="trash-outline" size={16} color="rgb(163, 163, 163)" />
+            </Pressable>
+          </View>
+        )}
+      />
+
+      <MealComposerSheet
+        visible={composerOpen}
+        meal={editingId ? editingMeal ?? null : null}
+        foods={foods ?? []}
+        onSave={handleSave}
+        onClose={() => setComposerOpen(false)}
+      />
+
+      <ConfirmDialog
+        visible={!!archiveTarget}
+        title="Remove meal"
+        message={`Remove "${archiveTarget?.name}"? Past log entries that used it are kept.`}
+        confirmLabel="Remove"
+        destructive
+        onConfirm={() => {
+          if (archiveTarget) archiveMeal.mutate(archiveTarget.id);
+          setArchiveTarget(null);
+        }}
+        onCancel={() => setArchiveTarget(null)}
+      />
+    </View>
+  );
+}

--- a/src/backend/database/migrations.ts
+++ b/src/backend/database/migrations.ts
@@ -505,6 +505,68 @@ const migrations: Migration[] = [
       CREATE INDEX idx_scheduled_workouts_split ON scheduled_workouts(split_id);
     `);
   },
+  // v19 → v20: Food & macro tracking. All data is per-install (single local user), so no
+  // user_id. `food_items` hold per-serving macros (calories/protein/carbs/fat per serving_size
+  // of serving_unit). `saved_meals` are reusable meals that are either composed of foods
+  // (`saved_meal_items`) or a manual fixed macro total (kind is explicit, not inferred from
+  // nulls). `food_log_entries` snapshot the resolved, already-scaled macros at log time (like
+  // workout_sets store literal weight/reps) so editing/archiving a food or meal never rewrites
+  // history and daily totals are a plain SUM over the day. No data seeding — foods/meals are
+  // added by the user (or seeded per-device via adb).
+  async (db) => {
+    await db.execAsync(`
+      CREATE TABLE food_items (
+        id TEXT PRIMARY KEY NOT NULL,
+        name TEXT NOT NULL,
+        serving_size REAL NOT NULL,
+        serving_unit TEXT NOT NULL DEFAULT 'g',
+        calories REAL NOT NULL,
+        protein_g REAL NOT NULL,
+        carbs_g REAL NOT NULL,
+        fat_g REAL NOT NULL,
+        archived_at TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE saved_meals (
+        id TEXT PRIMARY KEY NOT NULL,
+        name TEXT NOT NULL,
+        kind TEXT NOT NULL DEFAULT 'composed',
+        calories REAL,
+        protein_g REAL,
+        carbs_g REAL,
+        fat_g REAL,
+        archived_at TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE saved_meal_items (
+        id TEXT PRIMARY KEY NOT NULL,
+        saved_meal_id TEXT NOT NULL REFERENCES saved_meals(id) ON DELETE CASCADE,
+        food_id TEXT NOT NULL REFERENCES food_items(id),
+        quantity REAL NOT NULL,
+        position INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      CREATE INDEX idx_saved_meal_items_meal ON saved_meal_items(saved_meal_id);
+
+      CREATE TABLE food_log_entries (
+        id TEXT PRIMARY KEY NOT NULL,
+        date TEXT NOT NULL,
+        entry_type TEXT NOT NULL,
+        food_id TEXT REFERENCES food_items(id) ON DELETE SET NULL,
+        saved_meal_id TEXT REFERENCES saved_meals(id) ON DELETE SET NULL,
+        quantity REAL NOT NULL,
+        name TEXT NOT NULL,
+        calories REAL NOT NULL,
+        protein_g REAL NOT NULL,
+        carbs_g REAL NOT NULL,
+        fat_g REAL NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      CREATE INDEX idx_food_log_entries_date ON food_log_entries(date);
+    `);
+  },
 ];
 
 export async function runMigrations(db: SQLite.SQLiteDatabase): Promise<void> {

--- a/src/backend/models/foodItem.ts
+++ b/src/backend/models/foodItem.ts
@@ -1,0 +1,101 @@
+/** Food item model - CRUD for the food_items table (per-serving macros). */
+import type * as SQLite from 'expo-sqlite';
+import * as Crypto from 'expo-crypto';
+import type { FoodItem, FoodItemInput, ServingUnit } from '@shared/types/food';
+
+interface FoodItemRow {
+  id: string;
+  name: string;
+  serving_size: number;
+  serving_unit: string;
+  calories: number;
+  protein_g: number;
+  carbs_g: number;
+  fat_g: number;
+  archived_at: string | null;
+  created_at: string;
+}
+
+function mapRow(row: FoodItemRow): FoodItem {
+  return {
+    id: row.id,
+    name: row.name,
+    servingSize: row.serving_size,
+    servingUnit: row.serving_unit as ServingUnit,
+    calories: row.calories,
+    proteinG: row.protein_g,
+    carbsG: row.carbs_g,
+    fatG: row.fat_g,
+    archivedAt: row.archived_at,
+    createdAt: row.created_at,
+  };
+}
+
+export async function getById(db: SQLite.SQLiteDatabase, id: string): Promise<FoodItem | null> {
+  const row = await db.getFirstAsync<FoodItemRow>(`SELECT * FROM food_items WHERE id = ?`, id);
+  return row ? mapRow(row) : null;
+}
+
+/** All foods, alphabetical. Excludes archived unless requested. */
+export async function getAll(
+  db: SQLite.SQLiteDatabase,
+  includeArchived = false
+): Promise<FoodItem[]> {
+  const rows = await db.getAllAsync<FoodItemRow>(
+    `SELECT * FROM food_items
+     ${includeArchived ? '' : 'WHERE archived_at IS NULL'}
+     ORDER BY name COLLATE NOCASE ASC`
+  );
+  return rows.map(mapRow);
+}
+
+export async function create(db: SQLite.SQLiteDatabase, input: FoodItemInput): Promise<FoodItem> {
+  const id = Crypto.randomUUID();
+  await db.runAsync(
+    `INSERT INTO food_items (id, name, serving_size, serving_unit, calories, protein_g, carbs_g, fat_g)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    id,
+    input.name,
+    input.servingSize,
+    input.servingUnit,
+    input.calories,
+    input.proteinG,
+    input.carbsG,
+    input.fatG
+  );
+  const food = await getById(db, id);
+  if (!food) throw new Error(`Failed to create food with id ${id}`);
+  return food;
+}
+
+export async function update(
+  db: SQLite.SQLiteDatabase,
+  id: string,
+  input: FoodItemInput
+): Promise<FoodItem> {
+  await db.runAsync(
+    `UPDATE food_items
+     SET name = ?, serving_size = ?, serving_unit = ?, calories = ?, protein_g = ?, carbs_g = ?, fat_g = ?
+     WHERE id = ?`,
+    input.name,
+    input.servingSize,
+    input.servingUnit,
+    input.calories,
+    input.proteinG,
+    input.carbsG,
+    input.fatG,
+    id
+  );
+  const food = await getById(db, id);
+  if (!food) throw new Error(`Food with id ${id} not found after update`);
+  return food;
+}
+
+/** Soft-delete: keeps the row so composed meals and logged entries that reference it stay valid. */
+export async function archive(db: SQLite.SQLiteDatabase, id: string): Promise<void> {
+  await db.runAsync(`UPDATE food_items SET archived_at = datetime('now') WHERE id = ?`, id);
+}
+
+export async function unarchive(db: SQLite.SQLiteDatabase, id: string): Promise<void> {
+  await db.runAsync(`UPDATE food_items SET archived_at = NULL WHERE id = ?`, id);
+}

--- a/src/backend/models/foodLog.ts
+++ b/src/backend/models/foodLog.ts
@@ -1,0 +1,132 @@
+/** Food log model - CRUD for food_log_entries (a food/meal logged to a date, macros snapshotted). */
+import type * as SQLite from 'expo-sqlite';
+import * as Crypto from 'expo-crypto';
+import type { DailyTotals, FoodLogEntry, FoodLogEntryType } from '@shared/types/food';
+
+interface FoodLogRow {
+  id: string;
+  date: string;
+  entry_type: string;
+  food_id: string | null;
+  saved_meal_id: string | null;
+  quantity: number;
+  name: string;
+  calories: number;
+  protein_g: number;
+  carbs_g: number;
+  fat_g: number;
+  created_at: string;
+}
+
+function mapRow(row: FoodLogRow): FoodLogEntry {
+  return {
+    id: row.id,
+    date: row.date,
+    entryType: row.entry_type as FoodLogEntryType,
+    foodId: row.food_id,
+    savedMealId: row.saved_meal_id,
+    quantity: row.quantity,
+    name: row.name,
+    calories: row.calories,
+    proteinG: row.protein_g,
+    carbsG: row.carbs_g,
+    fatG: row.fat_g,
+    createdAt: row.created_at,
+  };
+}
+
+export async function getByDate(db: SQLite.SQLiteDatabase, date: string): Promise<FoodLogEntry[]> {
+  const rows = await db.getAllAsync<FoodLogRow>(
+    `SELECT * FROM food_log_entries WHERE date = ? ORDER BY created_at ASC`,
+    date
+  );
+  return rows.map(mapRow);
+}
+
+export async function getById(db: SQLite.SQLiteDatabase, id: string): Promise<FoodLogEntry | null> {
+  const row = await db.getFirstAsync<FoodLogRow>(`SELECT * FROM food_log_entries WHERE id = ?`, id);
+  return row ? mapRow(row) : null;
+}
+
+export async function getDailyTotals(db: SQLite.SQLiteDatabase, date: string): Promise<DailyTotals> {
+  const row = await db.getFirstAsync<{
+    calories: number | null;
+    protein_g: number | null;
+    carbs_g: number | null;
+    fat_g: number | null;
+    n: number;
+  }>(
+    `SELECT SUM(calories) AS calories, SUM(protein_g) AS protein_g,
+            SUM(carbs_g) AS carbs_g, SUM(fat_g) AS fat_g, COUNT(*) AS n
+     FROM food_log_entries WHERE date = ?`,
+    date
+  );
+  return {
+    calories: row?.calories ?? 0,
+    proteinG: row?.protein_g ?? 0,
+    carbsG: row?.carbs_g ?? 0,
+    fatG: row?.fat_g ?? 0,
+    entryCount: row?.n ?? 0,
+  };
+}
+
+interface CreateLogArgs {
+  date: string;
+  entryType: FoodLogEntryType;
+  foodId?: string | null;
+  savedMealId?: string | null;
+  quantity: number;
+  name: string;
+  calories: number;
+  proteinG: number;
+  carbsG: number;
+  fatG: number;
+}
+
+export async function create(db: SQLite.SQLiteDatabase, args: CreateLogArgs): Promise<FoodLogEntry> {
+  const id = Crypto.randomUUID();
+  await db.runAsync(
+    `INSERT INTO food_log_entries
+       (id, date, entry_type, food_id, saved_meal_id, quantity, name, calories, protein_g, carbs_g, fat_g)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    id,
+    args.date,
+    args.entryType,
+    args.foodId ?? null,
+    args.savedMealId ?? null,
+    args.quantity,
+    args.name,
+    args.calories,
+    args.proteinG,
+    args.carbsG,
+    args.fatG
+  );
+  const entry = await getById(db, id);
+  if (!entry) throw new Error(`Failed to create food log entry with id ${id}`);
+  return entry;
+}
+
+/** Update an entry's quantity and its (re-scaled) macro snapshot. */
+export async function updateSnapshot(
+  db: SQLite.SQLiteDatabase,
+  id: string,
+  args: { quantity: number; calories: number; proteinG: number; carbsG: number; fatG: number }
+): Promise<FoodLogEntry> {
+  await db.runAsync(
+    `UPDATE food_log_entries SET quantity = ?, calories = ?, protein_g = ?, carbs_g = ?, fat_g = ?
+     WHERE id = ?`,
+    args.quantity,
+    args.calories,
+    args.proteinG,
+    args.carbsG,
+    args.fatG,
+    id
+  );
+  const entry = await getById(db, id);
+  if (!entry) throw new Error(`Food log entry with id ${id} not found after update`);
+  return entry;
+}
+
+export async function remove(db: SQLite.SQLiteDatabase, id: string): Promise<void> {
+  await db.runAsync(`DELETE FROM food_log_entries WHERE id = ?`, id);
+}

--- a/src/backend/models/savedMeal.ts
+++ b/src/backend/models/savedMeal.ts
@@ -1,0 +1,198 @@
+/** Saved meal model - manages saved_meals + saved_meal_items (composed or manual meals). */
+import type * as SQLite from 'expo-sqlite';
+import * as Crypto from 'expo-crypto';
+import type { SavedMeal, SavedMealItem, SavedMealKind, ServingUnit } from '@shared/types/food';
+
+interface SavedMealRow {
+  id: string;
+  name: string;
+  kind: string;
+  calories: number | null;
+  protein_g: number | null;
+  carbs_g: number | null;
+  fat_g: number | null;
+  archived_at: string | null;
+  created_at: string;
+}
+
+function mapRow(row: SavedMealRow): SavedMeal {
+  return {
+    id: row.id,
+    name: row.name,
+    kind: row.kind as SavedMealKind,
+    calories: row.calories,
+    proteinG: row.protein_g,
+    carbsG: row.carbs_g,
+    fatG: row.fat_g,
+    archivedAt: row.archived_at,
+    createdAt: row.created_at,
+  };
+}
+
+export async function getById(db: SQLite.SQLiteDatabase, id: string): Promise<SavedMeal | null> {
+  const row = await db.getFirstAsync<SavedMealRow>(`SELECT * FROM saved_meals WHERE id = ?`, id);
+  return row ? mapRow(row) : null;
+}
+
+export async function getAll(
+  db: SQLite.SQLiteDatabase,
+  includeArchived = false
+): Promise<SavedMeal[]> {
+  const rows = await db.getAllAsync<SavedMealRow>(
+    `SELECT * FROM saved_meals
+     ${includeArchived ? '' : 'WHERE archived_at IS NULL'}
+     ORDER BY name COLLATE NOCASE ASC`
+  );
+  return rows.map(mapRow);
+}
+
+/** Items of a composed meal, with the referenced food joined in, ordered by position. */
+export async function getItems(db: SQLite.SQLiteDatabase, mealId: string): Promise<SavedMealItem[]> {
+  const rows = await db.getAllAsync<{
+    id: string;
+    saved_meal_id: string;
+    food_id: string;
+    quantity: number;
+    position: number;
+    f_name: string;
+    f_serving_size: number;
+    f_serving_unit: string;
+    f_calories: number;
+    f_protein_g: number;
+    f_carbs_g: number;
+    f_fat_g: number;
+    f_archived_at: string | null;
+    f_created_at: string;
+  }>(
+    `SELECT smi.id, smi.saved_meal_id, smi.food_id, smi.quantity, smi.position,
+            f.name AS f_name, f.serving_size AS f_serving_size, f.serving_unit AS f_serving_unit,
+            f.calories AS f_calories, f.protein_g AS f_protein_g, f.carbs_g AS f_carbs_g,
+            f.fat_g AS f_fat_g, f.archived_at AS f_archived_at, f.created_at AS f_created_at
+     FROM saved_meal_items smi
+     JOIN food_items f ON f.id = smi.food_id
+     WHERE smi.saved_meal_id = ?
+     ORDER BY smi.position ASC`,
+    mealId
+  );
+  return rows.map((r) => ({
+    id: r.id,
+    savedMealId: r.saved_meal_id,
+    foodId: r.food_id,
+    quantity: r.quantity,
+    position: r.position,
+    food: {
+      id: r.food_id,
+      name: r.f_name,
+      servingSize: r.f_serving_size,
+      servingUnit: r.f_serving_unit as ServingUnit,
+      calories: r.f_calories,
+      proteinG: r.f_protein_g,
+      carbsG: r.f_carbs_g,
+      fatG: r.f_fat_g,
+      archivedAt: r.f_archived_at,
+      createdAt: r.f_created_at,
+    },
+  }));
+}
+
+/**
+ * Aggregated totals for every composed meal, grouped by meal id (one query, no N+1).
+ * Manual meals aren't included here — their totals live on the saved_meals row.
+ */
+export async function getComposedTotals(
+  db: SQLite.SQLiteDatabase
+): Promise<Record<string, { calories: number; proteinG: number; carbsG: number; fatG: number }>> {
+  const rows = await db.getAllAsync<{
+    saved_meal_id: string;
+    calories: number;
+    protein_g: number;
+    carbs_g: number;
+    fat_g: number;
+  }>(
+    `SELECT smi.saved_meal_id,
+            SUM(f.calories  * smi.quantity / f.serving_size) AS calories,
+            SUM(f.protein_g * smi.quantity / f.serving_size) AS protein_g,
+            SUM(f.carbs_g   * smi.quantity / f.serving_size) AS carbs_g,
+            SUM(f.fat_g     * smi.quantity / f.serving_size) AS fat_g
+     FROM saved_meal_items smi
+     JOIN food_items f ON f.id = smi.food_id
+     GROUP BY smi.saved_meal_id`
+  );
+  const map: Record<string, { calories: number; proteinG: number; carbsG: number; fatG: number }> = {};
+  for (const r of rows) {
+    map[r.saved_meal_id] = {
+      calories: r.calories,
+      proteinG: r.protein_g,
+      carbsG: r.carbs_g,
+      fatG: r.fat_g,
+    };
+  }
+  return map;
+}
+
+interface CreateMealArgs {
+  name: string;
+  kind: SavedMealKind;
+  calories?: number | null;
+  proteinG?: number | null;
+  carbsG?: number | null;
+  fatG?: number | null;
+}
+
+export async function createMeal(db: SQLite.SQLiteDatabase, args: CreateMealArgs): Promise<string> {
+  const id = Crypto.randomUUID();
+  await db.runAsync(
+    `INSERT INTO saved_meals (id, name, kind, calories, protein_g, carbs_g, fat_g)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    id,
+    args.name,
+    args.kind,
+    args.calories ?? null,
+    args.proteinG ?? null,
+    args.carbsG ?? null,
+    args.fatG ?? null
+  );
+  return id;
+}
+
+export async function updateMeal(db: SQLite.SQLiteDatabase, id: string, args: CreateMealArgs): Promise<void> {
+  await db.runAsync(
+    `UPDATE saved_meals SET name = ?, kind = ?, calories = ?, protein_g = ?, carbs_g = ?, fat_g = ?
+     WHERE id = ?`,
+    args.name,
+    args.kind,
+    args.calories ?? null,
+    args.proteinG ?? null,
+    args.carbsG ?? null,
+    args.fatG ?? null,
+    id
+  );
+}
+
+/** Replace all items for a meal (delete + reinsert). Call within a transaction. */
+export async function replaceItems(
+  db: SQLite.SQLiteDatabase,
+  mealId: string,
+  items: { foodId: string; quantity: number }[]
+): Promise<void> {
+  await db.runAsync(`DELETE FROM saved_meal_items WHERE saved_meal_id = ?`, mealId);
+  for (let i = 0; i < items.length; i++) {
+    await db.runAsync(
+      `INSERT INTO saved_meal_items (id, saved_meal_id, food_id, quantity, position)
+       VALUES (?, ?, ?, ?, ?)`,
+      Crypto.randomUUID(),
+      mealId,
+      items[i].foodId,
+      items[i].quantity,
+      i
+    );
+  }
+}
+
+export async function archive(db: SQLite.SQLiteDatabase, id: string): Promise<void> {
+  await db.runAsync(`UPDATE saved_meals SET archived_at = datetime('now') WHERE id = ?`, id);
+}
+
+export async function unarchive(db: SQLite.SQLiteDatabase, id: string): Promise<void> {
+  await db.runAsync(`UPDATE saved_meals SET archived_at = NULL WHERE id = ?`, id);
+}

--- a/src/backend/services/foodService.ts
+++ b/src/backend/services/foodService.ts
@@ -1,0 +1,291 @@
+/** Food service - business logic for foods, saved meals, and daily macro logging. */
+import type * as SQLite from 'expo-sqlite';
+import * as foodItemModel from '@backend/models/foodItem';
+import * as savedMealModel from '@backend/models/savedMeal';
+import * as foodLogModel from '@backend/models/foodLog';
+import { APP_CONFIG } from '@config/app';
+import type {
+  DailyTotals,
+  FoodItem,
+  FoodItemInput,
+  FoodLogEntry,
+  Macros,
+  SavedMealInput,
+  SavedMealWithTotals,
+} from '@shared/types/food';
+
+const { validation } = APP_CONFIG;
+
+// ---- Macro math -------------------------------------------------------------
+
+const ZERO_MACROS: Macros = { calories: 0, proteinG: 0, carbsG: 0, fatG: 0 };
+
+/** Scale a food's per-serving macros to an amount expressed in the food's serving unit. */
+function scaleFood(food: FoodItem, quantity: number): Macros {
+  const factor = food.servingSize > 0 ? quantity / food.servingSize : 0;
+  return {
+    calories: food.calories * factor,
+    proteinG: food.proteinG * factor,
+    carbsG: food.carbsG * factor,
+    fatG: food.fatG * factor,
+  };
+}
+
+function scaleMacros(m: Macros, factor: number): Macros {
+  return {
+    calories: m.calories * factor,
+    proteinG: m.proteinG * factor,
+    carbsG: m.carbsG * factor,
+    fatG: m.fatG * factor,
+  };
+}
+
+// ---- Validation -------------------------------------------------------------
+
+function validateFoodInput(input: FoodItemInput): void {
+  const name = input.name.trim();
+  if (name.length < validation.foodName.min || name.length > validation.foodName.max) {
+    throw new Error('Enter a food name');
+  }
+  if (input.servingSize < validation.servingSize.min || input.servingSize > validation.servingSize.max) {
+    throw new Error('Enter a valid serving size');
+  }
+  for (const v of [input.calories, input.proteinG, input.carbsG, input.fatG]) {
+    if (!Number.isFinite(v) || v < validation.macro.min || v > validation.macro.max) {
+      throw new Error('Enter valid macro values');
+    }
+  }
+}
+
+// ---- Foods ------------------------------------------------------------------
+
+export function getFoods(db: SQLite.SQLiteDatabase, includeArchived = false): Promise<FoodItem[]> {
+  return foodItemModel.getAll(db, includeArchived);
+}
+
+export function createFood(db: SQLite.SQLiteDatabase, input: FoodItemInput): Promise<FoodItem> {
+  validateFoodInput(input);
+  return foodItemModel.create(db, { ...input, name: input.name.trim() });
+}
+
+export function updateFood(db: SQLite.SQLiteDatabase, id: string, input: FoodItemInput): Promise<FoodItem> {
+  validateFoodInput(input);
+  return foodItemModel.update(db, id, { ...input, name: input.name.trim() });
+}
+
+export function archiveFood(db: SQLite.SQLiteDatabase, id: string): Promise<void> {
+  return foodItemModel.archive(db, id);
+}
+
+// ---- Saved meals ------------------------------------------------------------
+
+/** Resolve a saved meal's per-serving totals: stored for manual, summed from items for composed. */
+function resolveMealTotals(
+  meal: { kind: string; calories: number | null; proteinG: number | null; carbsG: number | null; fatG: number | null },
+  composed: Macros | undefined
+): Macros {
+  if (meal.kind === 'manual') {
+    return {
+      calories: meal.calories ?? 0,
+      proteinG: meal.proteinG ?? 0,
+      carbsG: meal.carbsG ?? 0,
+      fatG: meal.fatG ?? 0,
+    };
+  }
+  return composed ?? ZERO_MACROS;
+}
+
+/** All saved meals with resolved totals (items not loaded — use getSavedMeal for the detail view). */
+export async function getSavedMeals(
+  db: SQLite.SQLiteDatabase,
+  includeArchived = false
+): Promise<SavedMealWithTotals[]> {
+  const [meals, composedMap] = await Promise.all([
+    savedMealModel.getAll(db, includeArchived),
+    savedMealModel.getComposedTotals(db),
+  ]);
+  return meals.map((meal) => ({
+    ...meal,
+    totals: resolveMealTotals(meal, composedMap[meal.id]),
+    items: [],
+  }));
+}
+
+/** A single saved meal with its items (for composed) and resolved totals. */
+export async function getSavedMeal(db: SQLite.SQLiteDatabase, id: string): Promise<SavedMealWithTotals | null> {
+  const meal = await savedMealModel.getById(db, id);
+  if (!meal) return null;
+  const items = meal.kind === 'composed' ? await savedMealModel.getItems(db, id) : [];
+  const composed = items.reduce<Macros>(
+    (acc, it) => (it.food ? addMacros(acc, scaleFood(it.food, it.quantity)) : acc),
+    ZERO_MACROS
+  );
+  return { ...meal, items, totals: resolveMealTotals(meal, meal.kind === 'composed' ? composed : undefined) };
+}
+
+function addMacros(a: Macros, b: Macros): Macros {
+  return {
+    calories: a.calories + b.calories,
+    proteinG: a.proteinG + b.proteinG,
+    carbsG: a.carbsG + b.carbsG,
+    fatG: a.fatG + b.fatG,
+  };
+}
+
+function validateMealInput(input: SavedMealInput): void {
+  if (input.name.trim().length < 1) throw new Error('Enter a meal name');
+  if (input.kind === 'composed') {
+    if (!input.items || input.items.length === 0) {
+      throw new Error('Add at least one food to the meal');
+    }
+    for (const it of input.items) {
+      if (it.quantity < validation.quantity.min || it.quantity > validation.quantity.max) {
+        throw new Error('Enter a valid quantity for each food');
+      }
+    }
+  } else {
+    const t = input.totals;
+    if (!t) throw new Error('Enter the meal macros');
+    for (const v of [t.calories, t.proteinG, t.carbsG, t.fatG]) {
+      if (!Number.isFinite(v) || v < validation.macro.min || v > validation.macro.max) {
+        throw new Error('Enter valid macro values');
+      }
+    }
+  }
+}
+
+export async function createSavedMeal(db: SQLite.SQLiteDatabase, input: SavedMealInput): Promise<string> {
+  validateMealInput(input);
+  let mealId = '';
+  await db.withTransactionAsync(async () => {
+    mealId = await savedMealModel.createMeal(db, {
+      name: input.name.trim(),
+      kind: input.kind,
+      calories: input.kind === 'manual' ? input.totals!.calories : null,
+      proteinG: input.kind === 'manual' ? input.totals!.proteinG : null,
+      carbsG: input.kind === 'manual' ? input.totals!.carbsG : null,
+      fatG: input.kind === 'manual' ? input.totals!.fatG : null,
+    });
+    if (input.kind === 'composed') {
+      await savedMealModel.replaceItems(db, mealId, input.items!);
+    }
+  });
+  return mealId;
+}
+
+export async function updateSavedMeal(db: SQLite.SQLiteDatabase, id: string, input: SavedMealInput): Promise<void> {
+  validateMealInput(input);
+  await db.withTransactionAsync(async () => {
+    await savedMealModel.updateMeal(db, id, {
+      name: input.name.trim(),
+      kind: input.kind,
+      calories: input.kind === 'manual' ? input.totals!.calories : null,
+      proteinG: input.kind === 'manual' ? input.totals!.proteinG : null,
+      carbsG: input.kind === 'manual' ? input.totals!.carbsG : null,
+      fatG: input.kind === 'manual' ? input.totals!.fatG : null,
+    });
+    // Composed meals own their items; a manual meal has none.
+    await savedMealModel.replaceItems(db, id, input.kind === 'composed' ? input.items! : []);
+  });
+}
+
+export function archiveSavedMeal(db: SQLite.SQLiteDatabase, id: string): Promise<void> {
+  return savedMealModel.archive(db, id);
+}
+
+// ---- Daily log --------------------------------------------------------------
+
+export async function getDay(
+  db: SQLite.SQLiteDatabase,
+  date: string
+): Promise<{ entries: FoodLogEntry[]; totals: DailyTotals }> {
+  const [entries, totals] = await Promise.all([
+    foodLogModel.getByDate(db, date),
+    foodLogModel.getDailyTotals(db, date),
+  ]);
+  return { entries, totals };
+}
+
+/** Log a food to a date. `quantity` is the amount in the food's serving unit; macros are snapshotted. */
+export async function logFood(
+  db: SQLite.SQLiteDatabase,
+  date: string,
+  foodId: string,
+  quantity: number
+): Promise<FoodLogEntry> {
+  if (quantity < validation.quantity.min || quantity > validation.quantity.max) {
+    throw new Error('Enter a valid quantity');
+  }
+  const food = await foodItemModel.getById(db, foodId);
+  if (!food) throw new Error('Food not found');
+  const macros = scaleFood(food, quantity);
+  return foodLogModel.create(db, {
+    date,
+    entryType: 'food',
+    foodId,
+    quantity,
+    name: food.name,
+    ...macros,
+  });
+}
+
+/** Log a saved meal to a date in one tap. `servings` defaults to 1; totals are re-resolved + snapshotted. */
+export async function logSavedMeal(
+  db: SQLite.SQLiteDatabase,
+  date: string,
+  savedMealId: string,
+  servings = 1
+): Promise<FoodLogEntry> {
+  if (servings < validation.quantity.min || servings > validation.quantity.max) {
+    throw new Error('Enter a valid number of servings');
+  }
+  const meal = await getSavedMeal(db, savedMealId);
+  if (!meal) throw new Error('Meal not found');
+  const macros = scaleMacros(meal.totals, servings);
+  return foodLogModel.create(db, {
+    date,
+    entryType: 'meal',
+    savedMealId,
+    quantity: servings,
+    name: meal.name,
+    ...macros,
+  });
+}
+
+/**
+ * Change a logged entry's quantity. Recomputes macros from the source food/meal when it still
+ * exists; otherwise scales the stored snapshot proportionally so history stays consistent.
+ */
+export async function updateLogQuantity(
+  db: SQLite.SQLiteDatabase,
+  id: string,
+  quantity: number
+): Promise<FoodLogEntry> {
+  if (quantity < validation.quantity.min || quantity > validation.quantity.max) {
+    throw new Error('Enter a valid quantity');
+  }
+  const entry = await foodLogModel.getById(db, id);
+  if (!entry) throw new Error('Entry not found');
+
+  let macros: Macros | null = null;
+  if (entry.entryType === 'food' && entry.foodId) {
+    const food = await foodItemModel.getById(db, entry.foodId);
+    if (food) macros = scaleFood(food, quantity);
+  } else if (entry.entryType === 'meal' && entry.savedMealId) {
+    const meal = await getSavedMeal(db, entry.savedMealId);
+    if (meal) macros = scaleMacros(meal.totals, quantity);
+  }
+  if (!macros) {
+    // Source gone — scale the existing snapshot from the old quantity.
+    const factor = entry.quantity > 0 ? quantity / entry.quantity : 0;
+    macros = scaleMacros(
+      { calories: entry.calories, proteinG: entry.proteinG, carbsG: entry.carbsG, fatG: entry.fatG },
+      factor
+    );
+  }
+  return foodLogModel.updateSnapshot(db, id, { quantity, ...macros });
+}
+
+export function deleteLogEntry(db: SQLite.SQLiteDatabase, id: string): Promise<void> {
+  return foodLogModel.remove(db, id);
+}

--- a/src/backend/store/settingsStore.ts
+++ b/src/backend/store/settingsStore.ts
@@ -10,6 +10,10 @@ interface SettingsStore extends AppSettings {
   loadSettings: (db: SQLite.SQLiteDatabase) => Promise<void>;
   updateUnits: (db: SQLite.SQLiteDatabase, units: UnitSystem) => Promise<void>;
   updateDefaultRestSeconds: (db: SQLite.SQLiteDatabase, seconds: number) => Promise<void>;
+  updateMacroTargets: (
+    db: SQLite.SQLiteDatabase,
+    targets: { dailyCalorieTarget: number; dailyProteinTarget: number }
+  ) => Promise<void>;
 }
 
 function getLocaleDefaultUnits(): UnitSystem {
@@ -50,17 +54,23 @@ async function writeSetting(db: SQLite.SQLiteDatabase, key: string, value: strin
 export const useSettingsStore = create<SettingsStore>((set) => ({
   units: APP_CONFIG.defaults.units,
   defaultRestSeconds: APP_CONFIG.defaults.restSeconds.strength,
+  dailyCalorieTarget: APP_CONFIG.defaults.dailyCalorieTarget,
+  dailyProteinTarget: APP_CONFIG.defaults.dailyProteinTarget,
   isLoaded: false,
 
   loadSettings: async (db) => {
     const unitsVal = await readSetting(db, 'units');
     const restVal = await readSetting(db, 'defaultRestSeconds');
+    const calorieVal = await readSetting(db, 'dailyCalorieTarget');
+    const proteinVal = await readSetting(db, 'dailyProteinTarget');
 
     const validUnits: UnitSystem[] = ['metric', 'imperial'];
     const units: UnitSystem = validUnits.includes(unitsVal as UnitSystem)
       ? (unitsVal as UnitSystem)
       : getLocaleDefaultUnits();
     const defaultRestSeconds = restVal ? parseInt(restVal, 10) : APP_CONFIG.defaults.restSeconds.strength;
+    const dailyCalorieTarget = calorieVal ? parseInt(calorieVal, 10) : APP_CONFIG.defaults.dailyCalorieTarget;
+    const dailyProteinTarget = proteinVal ? parseInt(proteinVal, 10) : APP_CONFIG.defaults.dailyProteinTarget;
 
     // Persist locale-based default if no setting exists yet
     if (!unitsVal) {
@@ -70,7 +80,7 @@ export const useSettingsStore = create<SettingsStore>((set) => ({
       await writeSetting(db, 'defaultRestSeconds', String(defaultRestSeconds));
     }
 
-    set({ units, defaultRestSeconds, isLoaded: true });
+    set({ units, defaultRestSeconds, dailyCalorieTarget, dailyProteinTarget, isLoaded: true });
   },
 
   updateUnits: async (db, units) => {
@@ -81,5 +91,11 @@ export const useSettingsStore = create<SettingsStore>((set) => ({
   updateDefaultRestSeconds: async (db, seconds) => {
     await writeSetting(db, 'defaultRestSeconds', String(seconds));
     set({ defaultRestSeconds: seconds });
+  },
+
+  updateMacroTargets: async (db, { dailyCalorieTarget, dailyProteinTarget }) => {
+    await writeSetting(db, 'dailyCalorieTarget', String(dailyCalorieTarget));
+    await writeSetting(db, 'dailyProteinTarget', String(dailyProteinTarget));
+    set({ dailyCalorieTarget, dailyProteinTarget });
   },
 }));

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -2,7 +2,7 @@
 export const APP_CONFIG = {
   database: {
     name: 'vext.db',
-    schemaVersion: 19,
+    schemaVersion: 20,
   },
   defaults: {
     restSeconds: {
@@ -13,6 +13,8 @@ export const APP_CONFIG = {
     units: 'metric' as const,
     historyPageSize: 20,
     searchDebounceMs: 300,
+    dailyCalorieTarget: 2000,
+    dailyProteinTarget: 150,
   },
   validation: {
     weight: { min: 0, max: 9999 },
@@ -22,5 +24,11 @@ export const APP_CONFIG = {
     exerciseName: { min: 1, max: 100 },
     workoutName: { min: 0, max: 200 },
     notes: { min: 0, max: 1000 },
+    foodName: { min: 1, max: 100 },
+    servingSize: { min: 0.01, max: 100000 },
+    macro: { min: 0, max: 100000 }, // calories or grams
+    quantity: { min: 0.01, max: 100000 },
+    calorieTarget: { min: 0, max: 20000 },
+    proteinTarget: { min: 0, max: 2000 },
   },
 } as const;

--- a/src/frontend/components/food/EditQuantitySheet.tsx
+++ b/src/frontend/components/food/EditQuantitySheet.tsx
@@ -1,0 +1,63 @@
+/** EditQuantitySheet - bottom sheet to change a logged entry's quantity (macros re-scale on save). */
+import React, { useState, useEffect } from 'react';
+import { Modal, Text, TextInput, Pressable } from 'react-native';
+import type { FoodLogEntry } from '@shared/types/food';
+
+type EditQuantitySheetProps = {
+  visible: boolean;
+  entry: FoodLogEntry | null;
+  onSave: (quantity: number) => void;
+  onClose: () => void;
+};
+
+export function EditQuantitySheet({ visible, entry, onSave, onClose }: EditQuantitySheetProps) {
+  const [value, setValue] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (visible && entry) {
+      setValue(String(entry.quantity));
+      setError(null);
+    }
+  }, [visible, entry]);
+
+  if (!entry) return null;
+
+  const isMeal = entry.entryType === 'meal';
+  const label = isMeal ? 'Servings' : 'Amount';
+
+  const handleSave = () => {
+    const q = parseFloat(value);
+    if (!Number.isFinite(q) || q <= 0) {
+      setError('Enter a valid amount');
+      return;
+    }
+    onSave(q);
+    onClose();
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <Pressable className="flex-1 justify-end bg-black/60" onPress={onClose}>
+        <Pressable className="rounded-t-2xl bg-background-50 px-6 pb-8 pt-5" onPress={(e) => e.stopPropagation()}>
+          <Text className="text-lg font-bold text-foreground">{entry.name}</Text>
+          <Text className="text-xs text-foreground-subtle mb-4">Edit {label.toLowerCase()}</Text>
+
+          <Text className="text-sm font-medium text-foreground mb-2">{label}</Text>
+          <TextInput
+            className="rounded-xl bg-background-100 px-4 py-3 text-base text-foreground"
+            keyboardType="decimal-pad"
+            value={value}
+            onChangeText={setValue}
+            autoFocus
+          />
+          {error && <Text className="mt-3 text-xs text-destructive">{error}</Text>}
+
+          <Pressable onPress={handleSave} className="mt-5 rounded-xl bg-primary py-3 items-center">
+            <Text className="text-base font-semibold text-background">Save</Text>
+          </Pressable>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}

--- a/src/frontend/components/food/FoodFormSheet.tsx
+++ b/src/frontend/components/food/FoodFormSheet.tsx
@@ -1,0 +1,178 @@
+/** FoodFormSheet - full-screen modal for creating/editing a food and its per-serving macros. */
+import React, { useState, useEffect } from 'react';
+import { Modal, View, Text, TextInput, Pressable, ScrollView } from 'react-native';
+import { cn } from '@frontend/lib/utils';
+import { SERVING_UNITS, MACRO_COLORS } from '@shared/constants/macros';
+import type { FoodItem, FoodItemInput, ServingUnit } from '@shared/types/food';
+
+type FoodFormSheetProps = {
+  visible: boolean;
+  food?: FoodItem | null;
+  onSave: (input: FoodItemInput) => void;
+  onClose: () => void;
+};
+
+function parseNum(s: string): number {
+  const n = parseFloat(s);
+  return Number.isFinite(n) ? n : NaN;
+}
+
+export function FoodFormSheet({ visible, food, onSave, onClose }: FoodFormSheetProps) {
+  const [name, setName] = useState('');
+  const [servingSize, setServingSize] = useState('100');
+  const [servingUnit, setServingUnit] = useState<ServingUnit>('g');
+  const [calories, setCalories] = useState('');
+  const [protein, setProtein] = useState('');
+  const [carbs, setCarbs] = useState('');
+  const [fat, setFat] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const isEditing = !!food;
+
+  useEffect(() => {
+    if (!visible) return;
+    if (food) {
+      setName(food.name);
+      setServingSize(String(food.servingSize));
+      setServingUnit(food.servingUnit);
+      setCalories(String(food.calories));
+      setProtein(String(food.proteinG));
+      setCarbs(String(food.carbsG));
+      setFat(String(food.fatG));
+    } else {
+      setName('');
+      setServingSize('100');
+      setServingUnit('g');
+      setCalories('');
+      setProtein('');
+      setCarbs('');
+      setFat('');
+    }
+    setError(null);
+  }, [visible, food]);
+
+  const handleSave = () => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError('Enter a food name');
+      return;
+    }
+    const size = parseNum(servingSize);
+    if (!(size > 0)) {
+      setError('Enter a valid serving size');
+      return;
+    }
+    const macros = [calories, protein, carbs, fat].map(parseNum);
+    if (macros.some((m) => !Number.isFinite(m) || m < 0)) {
+      setError('Enter valid macro values (0 or more)');
+      return;
+    }
+    onSave({
+      name: trimmed,
+      servingSize: size,
+      servingUnit,
+      calories: macros[0],
+      proteinG: macros[1],
+      carbsG: macros[2],
+      fatG: macros[3],
+    });
+    onClose();
+  };
+
+  const macroInput = (
+    label: string,
+    value: string,
+    setter: (v: string) => void,
+    color: string,
+    placeholder: string
+  ) => (
+    <View className="flex-1">
+      <View className="flex-row items-center gap-1.5 mb-1.5">
+        <View className="h-2 w-2 rounded-full" style={{ backgroundColor: color }} />
+        <Text className="text-xs font-medium text-foreground-muted">{label}</Text>
+      </View>
+      <TextInput
+        className="rounded-xl bg-background-50 px-3 py-3 text-base text-foreground"
+        keyboardType="decimal-pad"
+        placeholder={placeholder}
+        placeholderTextColor="rgb(115, 115, 115)"
+        value={value}
+        onChangeText={setter}
+      />
+    </View>
+  );
+
+  return (
+    <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
+      <View className="flex-1 bg-background">
+        <View className="flex-row items-center justify-between border-b border-background-100 px-4 pb-3 pt-14">
+          <Pressable onPress={onClose} className="py-1">
+            <Text className="text-base text-foreground-muted">Cancel</Text>
+          </Pressable>
+          <Text className="text-lg font-bold text-foreground">{isEditing ? 'Edit Food' : 'New Food'}</Text>
+          <Pressable onPress={handleSave} className="py-1">
+            <Text className="text-base font-semibold text-primary">Save</Text>
+          </Pressable>
+        </View>
+
+        <ScrollView className="flex-1" contentContainerClassName="px-4 py-4 pb-10">
+          <Text className="text-sm font-medium text-foreground">Name *</Text>
+          <TextInput
+            className="mt-2 rounded-xl bg-background-50 px-4 py-3 text-base text-foreground"
+            placeholder="e.g. Chicken breast"
+            placeholderTextColor="rgb(115, 115, 115)"
+            value={name}
+            onChangeText={setName}
+            autoCapitalize="sentences"
+          />
+
+          <Text className="mt-5 text-sm font-medium text-foreground">Serving *</Text>
+          <Text className="mt-1 text-xs text-foreground-subtle">Macros below are per this amount.</Text>
+          <View className="mt-2 flex-row gap-2">
+            <TextInput
+              className="w-24 rounded-xl bg-background-50 px-4 py-3 text-base text-foreground"
+              keyboardType="decimal-pad"
+              placeholder="100"
+              placeholderTextColor="rgb(115, 115, 115)"
+              value={servingSize}
+              onChangeText={setServingSize}
+            />
+            <View className="flex-1 flex-row gap-2">
+              {SERVING_UNITS.map((u) => (
+                <Pressable
+                  key={u.value}
+                  onPress={() => setServingUnit(u.value)}
+                  className={cn(
+                    'flex-1 rounded-xl py-3 items-center justify-center',
+                    servingUnit === u.value ? 'bg-primary' : 'bg-background-50'
+                  )}
+                >
+                  <Text
+                    className={cn(
+                      'text-sm font-medium',
+                      servingUnit === u.value ? 'text-background' : 'text-foreground-muted'
+                    )}
+                  >
+                    {u.label}
+                  </Text>
+                </Pressable>
+              ))}
+            </View>
+          </View>
+
+          <Text className="mt-5 text-sm font-medium text-foreground">Macros per serving *</Text>
+          <View className="mt-2 flex-row gap-2">
+            {macroInput('Calories', calories, setCalories, MACRO_COLORS.calories, 'kcal')}
+            {macroInput('Protein', protein, setProtein, MACRO_COLORS.protein, 'g')}
+          </View>
+          <View className="mt-3 flex-row gap-2">
+            {macroInput('Carbs', carbs, setCarbs, MACRO_COLORS.carbs, 'g')}
+            {macroInput('Fat', fat, setFat, MACRO_COLORS.fat, 'g')}
+          </View>
+
+          {error && <Text className="mt-4 text-sm text-destructive">{error}</Text>}
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+}

--- a/src/frontend/components/food/FoodPickerSheet.tsx
+++ b/src/frontend/components/food/FoodPickerSheet.tsx
@@ -1,0 +1,173 @@
+/** FoodPickerSheet - full-screen modal to pick a food + quantity. Reused for logging and meal composing. */
+import React, { useState, useMemo, useEffect } from 'react';
+import { Modal, View, Text, TextInput, Pressable, FlatList } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { MACRO_COLORS } from '@shared/constants/macros';
+import { formatCalories, formatGrams, formatAmount } from '@shared/utils/formatting';
+import type { FoodItem } from '@shared/types/food';
+
+type FoodPickerSheetProps = {
+  visible: boolean;
+  foods: FoodItem[];
+  title?: string;
+  confirmLabel?: string;
+  onPick: (food: FoodItem, quantity: number) => void;
+  onClose: () => void;
+};
+
+export function FoodPickerSheet({
+  visible,
+  foods,
+  title = 'Add food',
+  confirmLabel = 'Add',
+  onPick,
+  onClose,
+}: FoodPickerSheetProps) {
+  const [query, setQuery] = useState('');
+  const [selected, setSelected] = useState<FoodItem | null>(null);
+  const [qty, setQty] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (visible) {
+      setQuery('');
+      setSelected(null);
+      setQty('');
+      setError(null);
+    }
+  }, [visible]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return q ? foods.filter((f) => f.name.toLowerCase().includes(q)) : foods;
+  }, [foods, query]);
+
+  const pickFood = (food: FoodItem) => {
+    setSelected(food);
+    setQty(String(food.servingSize));
+    setError(null);
+  };
+
+  const quantityNum = parseFloat(qty);
+  const factor = selected && selected.servingSize > 0 && Number.isFinite(quantityNum)
+    ? quantityNum / selected.servingSize
+    : 0;
+
+  const handleConfirm = () => {
+    if (!selected) return;
+    if (!(quantityNum > 0)) {
+      setError('Enter a valid amount');
+      return;
+    }
+    onPick(selected, quantityNum);
+    onClose();
+  };
+
+  return (
+    <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
+      <View className="flex-1 bg-background">
+        {/* Header */}
+        <View className="flex-row items-center justify-between border-b border-background-100 px-4 pb-3 pt-14">
+          <Pressable onPress={selected ? () => setSelected(null) : onClose} className="py-1 flex-row items-center gap-1">
+            {selected ? (
+              <>
+                <Ionicons name="chevron-back" size={18} color="rgb(163, 163, 163)" />
+                <Text className="text-base text-foreground-muted">Back</Text>
+              </>
+            ) : (
+              <Text className="text-base text-foreground-muted">Cancel</Text>
+            )}
+          </Pressable>
+          <Text className="text-lg font-bold text-foreground">{selected ? selected.name : title}</Text>
+          {selected ? (
+            <Pressable onPress={handleConfirm} className="py-1">
+              <Text className="text-base font-semibold text-primary">{confirmLabel}</Text>
+            </Pressable>
+          ) : (
+            <View className="w-16" />
+          )}
+        </View>
+
+        {selected ? (
+          /* Quantity step */
+          <View className="px-4 py-5">
+            <Text className="text-sm font-medium text-foreground mb-2">
+              Amount ({selected.servingUnit})
+            </Text>
+            <TextInput
+              className="rounded-xl bg-background-50 px-4 py-3 text-base text-foreground"
+              keyboardType="decimal-pad"
+              value={qty}
+              onChangeText={(t) => {
+                setQty(t);
+                setError(null);
+              }}
+              autoFocus
+            />
+            <Text className="mt-2 text-xs text-foreground-subtle">
+              Macros are per {formatAmount(selected.servingSize, selected.servingUnit)}.
+            </Text>
+
+            {/* Live preview */}
+            <View className="mt-5 rounded-xl bg-background-50 p-4">
+              <Text className="text-xs font-medium text-foreground-muted mb-2">This adds</Text>
+              <Text className="text-2xl font-bold text-foreground">
+                {formatCalories(selected.calories * factor)}
+              </Text>
+              <View className="mt-2 flex-row gap-4">
+                <Text className="text-sm" style={{ color: MACRO_COLORS.protein }}>
+                  P {formatGrams(selected.proteinG * factor)}
+                </Text>
+                <Text className="text-sm" style={{ color: MACRO_COLORS.carbs }}>
+                  C {formatGrams(selected.carbsG * factor)}
+                </Text>
+                <Text className="text-sm" style={{ color: MACRO_COLORS.fat }}>
+                  F {formatGrams(selected.fatG * factor)}
+                </Text>
+              </View>
+            </View>
+            {error && <Text className="mt-3 text-sm text-destructive">{error}</Text>}
+          </View>
+        ) : (
+          /* Food list */
+          <>
+            <View className="px-4 py-3">
+              <TextInput
+                className="rounded-xl bg-background-50 px-4 py-3 text-base text-foreground"
+                placeholder="Search foods"
+                placeholderTextColor="rgb(115, 115, 115)"
+                value={query}
+                onChangeText={setQuery}
+              />
+            </View>
+            <FlatList
+              data={filtered}
+              keyExtractor={(item) => item.id}
+              contentContainerClassName="px-4 pb-10"
+              ListEmptyComponent={
+                <Text className="text-sm text-foreground-subtle text-center py-8">
+                  {foods.length === 0 ? 'No foods yet. Add foods from Manage foods.' : 'No matches'}
+                </Text>
+              }
+              renderItem={({ item }) => (
+                <Pressable
+                  onPress={() => pickFood(item)}
+                  className="flex-row items-center justify-between rounded-xl bg-background-50 px-4 py-3 mb-2"
+                >
+                  <View className="flex-1 pr-3">
+                    <Text className="text-base text-foreground">{item.name}</Text>
+                    <Text className="text-xs text-foreground-subtle">
+                      {formatCalories(item.calories)} · P {formatGrams(item.proteinG)} · per{' '}
+                      {formatAmount(item.servingSize, item.servingUnit)}
+                    </Text>
+                  </View>
+                  <Ionicons name="add-circle-outline" size={22} color="rgb(52, 211, 153)" />
+                </Pressable>
+              )}
+            />
+          </>
+        )}
+      </View>
+    </Modal>
+  );
+}

--- a/src/frontend/components/food/MacroChips.tsx
+++ b/src/frontend/components/food/MacroChips.tsx
@@ -1,0 +1,29 @@
+/** MacroChips - compact row showing consumed calories + protein/carbs/fat totals with color dots. */
+import React from 'react';
+import { View, Text } from 'react-native';
+import { MACRO_COLORS } from '@shared/constants/macros';
+import { formatCalories, formatGrams } from '@shared/utils/formatting';
+import type { Macros } from '@shared/types/food';
+
+function Chip({ label, text, color }: { label: string; text: string; color: string }) {
+  return (
+    <View className="flex-1 items-center">
+      <View className="flex-row items-center gap-1">
+        <View className="h-2 w-2 rounded-full" style={{ backgroundColor: color }} />
+        <Text className="text-xs text-foreground-subtle">{label}</Text>
+      </View>
+      <Text className="mt-1 text-sm font-semibold text-foreground">{text}</Text>
+    </View>
+  );
+}
+
+export function MacroChips({ totals }: { totals: Macros }) {
+  return (
+    <View className="flex-row">
+      <Chip label="Calories" text={formatCalories(totals.calories)} color={MACRO_COLORS.calories} />
+      <Chip label="Protein" text={formatGrams(totals.proteinG)} color={MACRO_COLORS.protein} />
+      <Chip label="Carbs" text={formatGrams(totals.carbsG)} color={MACRO_COLORS.carbs} />
+      <Chip label="Fat" text={formatGrams(totals.fatG)} color={MACRO_COLORS.fat} />
+    </View>
+  );
+}

--- a/src/frontend/components/food/MacroProgressBar.tsx
+++ b/src/frontend/components/food/MacroProgressBar.tsx
@@ -1,0 +1,40 @@
+/** MacroProgressBar - a labeled progress bar showing consumed vs target with remaining/over text. */
+import React from 'react';
+import { View, Text } from 'react-native';
+import { MACRO_OVER_COLOR } from '@shared/constants/macros';
+
+type MacroProgressBarProps = {
+  label: string;
+  value: number;
+  target: number;
+  unit: string;
+  color: string;
+};
+
+export function MacroProgressBar({ label, value, target, unit, color }: MacroProgressBarProps) {
+  const pct = target > 0 ? Math.min(1, value / target) : 0;
+  const over = target > 0 && value > target;
+  const remaining = Math.max(0, target - value);
+
+  return (
+    <View>
+      <View className="flex-row items-baseline justify-between mb-1.5">
+        <Text className="text-xs font-medium text-foreground-muted">{label}</Text>
+        <Text className="text-xs text-foreground-subtle">
+          {Math.round(value)} / {Math.round(target)} {unit}
+        </Text>
+      </View>
+      <View className="h-2 rounded-full bg-background-100 overflow-hidden">
+        <View
+          className="h-full rounded-full"
+          style={{ width: `${pct * 100}%`, backgroundColor: over ? MACRO_OVER_COLOR : color }}
+        />
+      </View>
+      <Text className="mt-1 text-xs" style={{ color: over ? MACRO_OVER_COLOR : color }}>
+        {over
+          ? `${Math.round(value - target)} ${unit} over`
+          : `${Math.round(remaining)} ${unit} left`}
+      </Text>
+    </View>
+  );
+}

--- a/src/frontend/components/food/MealComposerSheet.tsx
+++ b/src/frontend/components/food/MealComposerSheet.tsx
@@ -1,0 +1,252 @@
+/** MealComposerSheet - full-screen modal to create/edit a saved meal (composed of foods or manual totals). */
+import React, { useState, useEffect, useMemo } from 'react';
+import { Modal, View, Text, TextInput, Pressable, ScrollView } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { cn } from '@frontend/lib/utils';
+import { FoodPickerSheet } from '@frontend/components/food/FoodPickerSheet';
+import { MACRO_COLORS } from '@shared/constants/macros';
+import { formatCalories, formatGrams, formatAmount } from '@shared/utils/formatting';
+import type { FoodItem, Macros, SavedMealInput, SavedMealKind, SavedMealWithTotals } from '@shared/types/food';
+
+type ComposedItem = { food: FoodItem; quantity: number };
+
+type MealComposerSheetProps = {
+  visible: boolean;
+  meal?: SavedMealWithTotals | null;
+  foods: FoodItem[];
+  onSave: (input: SavedMealInput) => void;
+  onClose: () => void;
+};
+
+function parseNum(s: string): number {
+  const n = parseFloat(s);
+  return Number.isFinite(n) ? n : NaN;
+}
+
+export function MealComposerSheet({ visible, meal, foods, onSave, onClose }: MealComposerSheetProps) {
+  const [name, setName] = useState('');
+  const [kind, setKind] = useState<SavedMealKind>('composed');
+  const [items, setItems] = useState<ComposedItem[]>([]);
+  const [calories, setCalories] = useState('');
+  const [protein, setProtein] = useState('');
+  const [carbs, setCarbs] = useState('');
+  const [fat, setFat] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const isEditing = !!meal;
+
+  useEffect(() => {
+    if (!visible) return;
+    if (meal) {
+      setName(meal.name);
+      setKind(meal.kind);
+      setItems(meal.items.filter((it) => it.food).map((it) => ({ food: it.food!, quantity: it.quantity })));
+      setCalories(meal.kind === 'manual' ? String(meal.calories ?? '') : '');
+      setProtein(meal.kind === 'manual' ? String(meal.proteinG ?? '') : '');
+      setCarbs(meal.kind === 'manual' ? String(meal.carbsG ?? '') : '');
+      setFat(meal.kind === 'manual' ? String(meal.fatG ?? '') : '');
+    } else {
+      setName('');
+      setKind('composed');
+      setItems([]);
+      setCalories('');
+      setProtein('');
+      setCarbs('');
+      setFat('');
+    }
+    setError(null);
+  }, [visible, meal]);
+
+  const composedTotals: Macros = useMemo(
+    () =>
+      items.reduce<Macros>(
+        (acc, it) => {
+          const f = it.food.servingSize > 0 ? it.quantity / it.food.servingSize : 0;
+          return {
+            calories: acc.calories + it.food.calories * f,
+            proteinG: acc.proteinG + it.food.proteinG * f,
+            carbsG: acc.carbsG + it.food.carbsG * f,
+            fatG: acc.fatG + it.food.fatG * f,
+          };
+        },
+        { calories: 0, proteinG: 0, carbsG: 0, fatG: 0 }
+      ),
+    [items]
+  );
+
+  const handleSave = () => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError('Enter a meal name');
+      return;
+    }
+    if (kind === 'composed') {
+      if (items.length === 0) {
+        setError('Add at least one food');
+        return;
+      }
+      onSave({
+        name: trimmed,
+        kind: 'composed',
+        items: items.map((it) => ({ foodId: it.food.id, quantity: it.quantity })),
+      });
+    } else {
+      const macros = [calories, protein, carbs, fat].map(parseNum);
+      if (macros.some((m) => !Number.isFinite(m) || m < 0)) {
+        setError('Enter valid macro values (0 or more)');
+        return;
+      }
+      onSave({
+        name: trimmed,
+        kind: 'manual',
+        totals: { calories: macros[0], proteinG: macros[1], carbsG: macros[2], fatG: macros[3] },
+      });
+    }
+    onClose();
+  };
+
+  const manualInput = (label: string, value: string, setter: (v: string) => void, color: string) => (
+    <View className="flex-1">
+      <View className="flex-row items-center gap-1.5 mb-1.5">
+        <View className="h-2 w-2 rounded-full" style={{ backgroundColor: color }} />
+        <Text className="text-xs font-medium text-foreground-muted">{label}</Text>
+      </View>
+      <TextInput
+        className="rounded-xl bg-background-50 px-3 py-3 text-base text-foreground"
+        keyboardType="decimal-pad"
+        placeholder="0"
+        placeholderTextColor="rgb(115, 115, 115)"
+        value={value}
+        onChangeText={setter}
+      />
+    </View>
+  );
+
+  return (
+    <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
+      <View className="flex-1 bg-background">
+        <View className="flex-row items-center justify-between border-b border-background-100 px-4 pb-3 pt-14">
+          <Pressable onPress={onClose} className="py-1">
+            <Text className="text-base text-foreground-muted">Cancel</Text>
+          </Pressable>
+          <Text className="text-lg font-bold text-foreground">{isEditing ? 'Edit Meal' : 'New Meal'}</Text>
+          <Pressable onPress={handleSave} className="py-1">
+            <Text className="text-base font-semibold text-primary">Save</Text>
+          </Pressable>
+        </View>
+
+        <ScrollView className="flex-1" contentContainerClassName="px-4 py-4 pb-10">
+          <Text className="text-sm font-medium text-foreground">Name *</Text>
+          <TextInput
+            className="mt-2 rounded-xl bg-background-50 px-4 py-3 text-base text-foreground"
+            placeholder="e.g. Chicken & rice lunch"
+            placeholderTextColor="rgb(115, 115, 115)"
+            value={name}
+            onChangeText={setName}
+            autoCapitalize="sentences"
+          />
+
+          {/* Kind toggle */}
+          <View className="mt-4 flex-row gap-2">
+            {(['composed', 'manual'] as SavedMealKind[]).map((k) => (
+              <Pressable
+                key={k}
+                onPress={() => setKind(k)}
+                className={cn(
+                  'flex-1 rounded-xl py-3 items-center',
+                  kind === k ? 'bg-primary' : 'bg-background-50'
+                )}
+              >
+                <Text className={cn('text-sm font-medium', kind === k ? 'text-background' : 'text-foreground-muted')}>
+                  {k === 'composed' ? 'From foods' : 'Manual macros'}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+
+          {kind === 'composed' ? (
+            <>
+              <View className="mt-5 flex-row items-center justify-between">
+                <Text className="text-sm font-medium text-foreground">Foods</Text>
+                <Pressable
+                  onPress={() => setPickerOpen(true)}
+                  className="flex-row items-center gap-1 rounded-lg bg-background-50 px-3 py-2"
+                >
+                  <Ionicons name="add" size={16} color="rgb(52, 211, 153)" />
+                  <Text className="text-sm text-primary">Add food</Text>
+                </Pressable>
+              </View>
+
+              {items.length === 0 ? (
+                <Text className="mt-3 text-sm text-foreground-subtle text-center py-6">No foods added yet</Text>
+              ) : (
+                <View className="mt-3 gap-2">
+                  {items.map((it, idx) => {
+                    const f = it.food.servingSize > 0 ? it.quantity / it.food.servingSize : 0;
+                    return (
+                      <View
+                        key={`${it.food.id}-${idx}`}
+                        className="flex-row items-center justify-between rounded-xl bg-background-50 px-4 py-3"
+                      >
+                        <View className="flex-1 pr-3">
+                          <Text className="text-base text-foreground">{it.food.name}</Text>
+                          <Text className="text-xs text-foreground-subtle">
+                            {formatAmount(it.quantity, it.food.servingUnit)} ·{' '}
+                            {formatCalories(it.food.calories * f)} · P {formatGrams(it.food.proteinG * f)}
+                          </Text>
+                        </View>
+                        <Pressable onPress={() => setItems((prev) => prev.filter((_, i) => i !== idx))} className="p-1.5">
+                          <Ionicons name="close-circle" size={20} color="rgb(163, 163, 163)" />
+                        </Pressable>
+                      </View>
+                    );
+                  })}
+                </View>
+              )}
+
+              {/* Live totals */}
+              <View className="mt-4 rounded-xl bg-background-50 p-4">
+                <Text className="text-xs font-medium text-foreground-muted mb-1">Meal total</Text>
+                <Text className="text-2xl font-bold text-foreground">{formatCalories(composedTotals.calories)}</Text>
+                <View className="mt-2 flex-row gap-4">
+                  <Text className="text-sm" style={{ color: MACRO_COLORS.protein }}>
+                    P {formatGrams(composedTotals.proteinG)}
+                  </Text>
+                  <Text className="text-sm" style={{ color: MACRO_COLORS.carbs }}>
+                    C {formatGrams(composedTotals.carbsG)}
+                  </Text>
+                  <Text className="text-sm" style={{ color: MACRO_COLORS.fat }}>
+                    F {formatGrams(composedTotals.fatG)}
+                  </Text>
+                </View>
+              </View>
+            </>
+          ) : (
+            <>
+              <Text className="mt-5 text-sm font-medium text-foreground">Macros per serving *</Text>
+              <View className="mt-2 flex-row gap-2">
+                {manualInput('Calories', calories, setCalories, MACRO_COLORS.calories)}
+                {manualInput('Protein', protein, setProtein, MACRO_COLORS.protein)}
+              </View>
+              <View className="mt-3 flex-row gap-2">
+                {manualInput('Carbs', carbs, setCarbs, MACRO_COLORS.carbs)}
+                {manualInput('Fat', fat, setFat, MACRO_COLORS.fat)}
+              </View>
+            </>
+          )}
+
+          {error && <Text className="mt-4 text-sm text-destructive">{error}</Text>}
+        </ScrollView>
+      </View>
+
+      <FoodPickerSheet
+        visible={pickerOpen}
+        foods={foods}
+        title="Add food to meal"
+        onPick={(food, quantity) => setItems((prev) => [...prev, { food, quantity }])}
+        onClose={() => setPickerOpen(false)}
+      />
+    </Modal>
+  );
+}

--- a/src/frontend/components/food/TargetsSheet.tsx
+++ b/src/frontend/components/food/TargetsSheet.tsx
@@ -1,0 +1,79 @@
+/** TargetsSheet - bottom sheet to set the per-install daily calorie & protein targets. */
+import React, { useState, useEffect } from 'react';
+import { Modal, Text, TextInput, Pressable } from 'react-native';
+import { APP_CONFIG } from '@config/app';
+
+type TargetsSheetProps = {
+  visible: boolean;
+  calorieTarget: number;
+  proteinTarget: number;
+  onSave: (calorieTarget: number, proteinTarget: number) => void;
+  onClose: () => void;
+};
+
+const { calorieTarget: CAL, proteinTarget: PRO } = APP_CONFIG.validation;
+
+export function TargetsSheet({ visible, calorieTarget, proteinTarget, onSave, onClose }: TargetsSheetProps) {
+  const [calories, setCalories] = useState('');
+  const [protein, setProtein] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (visible) {
+      setCalories(String(calorieTarget));
+      setProtein(String(proteinTarget));
+      setError(null);
+    }
+  }, [visible, calorieTarget, proteinTarget]);
+
+  const handleSave = () => {
+    const cals = parseInt(calories, 10);
+    const pro = parseInt(protein, 10);
+    if (!Number.isFinite(cals) || cals < CAL.min || cals > CAL.max) {
+      setError('Enter a valid calorie target');
+      return;
+    }
+    if (!Number.isFinite(pro) || pro < PRO.min || pro > PRO.max) {
+      setError('Enter a valid protein target');
+      return;
+    }
+    onSave(cals, pro);
+    onClose();
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <Pressable className="flex-1 justify-end bg-black/60" onPress={onClose}>
+        <Pressable className="rounded-t-2xl bg-background-50 px-6 pb-8 pt-5" onPress={(e) => e.stopPropagation()}>
+          <Text className="text-lg font-bold text-foreground mb-4">Daily Targets</Text>
+
+          <Text className="text-sm font-medium text-foreground mb-2">Calorie target (kcal)</Text>
+          <TextInput
+            className="rounded-xl bg-background-100 px-4 py-3 text-base text-foreground"
+            keyboardType="number-pad"
+            placeholder="2000"
+            placeholderTextColor="rgb(115, 115, 115)"
+            value={calories}
+            onChangeText={setCalories}
+          />
+
+          <Text className="text-sm font-medium text-foreground mb-2 mt-4">Protein target (g)</Text>
+          <TextInput
+            className="rounded-xl bg-background-100 px-4 py-3 text-base text-foreground"
+            keyboardType="number-pad"
+            placeholder="150"
+            placeholderTextColor="rgb(115, 115, 115)"
+            value={protein}
+            onChangeText={setProtein}
+          />
+
+          {error && <Text className="mt-3 text-xs text-destructive">{error}</Text>}
+
+          <Pressable onPress={handleSave} className="mt-5 rounded-xl bg-primary py-3 items-center">
+            <Text className="text-base font-semibold text-background">Save</Text>
+          </Pressable>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}

--- a/src/frontend/hooks/useFood.ts
+++ b/src/frontend/hooks/useFood.ts
@@ -1,0 +1,101 @@
+/** Food hooks - React Query queries and mutations for foods, saved meals, and daily logging. */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import * as foodService from '@backend/services/foodService';
+import { useDatabase } from '@frontend/hooks/useDatabase';
+import type { FoodItemInput, SavedMealInput } from '@shared/types/food';
+
+// ---- Queries ----------------------------------------------------------------
+
+export function useFoods(includeArchived = false) {
+  const db = useDatabase();
+  return useQuery({
+    queryKey: ['food', 'items', includeArchived],
+    queryFn: () => foodService.getFoods(db, includeArchived),
+  });
+}
+
+export function useSavedMeals() {
+  const db = useDatabase();
+  return useQuery({
+    queryKey: ['food', 'meals'],
+    queryFn: () => foodService.getSavedMeals(db),
+  });
+}
+
+export function useSavedMeal(id: string | null) {
+  const db = useDatabase();
+  return useQuery({
+    queryKey: ['food', 'meal', id],
+    queryFn: () => (id ? foodService.getSavedMeal(db, id) : null),
+    enabled: id != null,
+  });
+}
+
+export function useFoodDay(date: string) {
+  const db = useDatabase();
+  return useQuery({
+    queryKey: ['food', 'day', date],
+    queryFn: () => foodService.getDay(db, date),
+  });
+}
+
+// ---- Mutations --------------------------------------------------------------
+
+function useFoodMutation<TArgs>(fn: (db: ReturnType<typeof useDatabase>, args: TArgs) => Promise<unknown>) {
+  const db = useDatabase();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (args: TArgs) => fn(db, args),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['food'] }),
+  });
+}
+
+export function useCreateFood() {
+  return useFoodMutation((db, input: FoodItemInput) => foodService.createFood(db, input));
+}
+
+export function useUpdateFood() {
+  return useFoodMutation((db, args: { id: string; input: FoodItemInput }) =>
+    foodService.updateFood(db, args.id, args.input)
+  );
+}
+
+export function useArchiveFood() {
+  return useFoodMutation((db, id: string) => foodService.archiveFood(db, id));
+}
+
+export function useCreateSavedMeal() {
+  return useFoodMutation((db, input: SavedMealInput) => foodService.createSavedMeal(db, input));
+}
+
+export function useUpdateSavedMeal() {
+  return useFoodMutation((db, args: { id: string; input: SavedMealInput }) =>
+    foodService.updateSavedMeal(db, args.id, args.input)
+  );
+}
+
+export function useArchiveSavedMeal() {
+  return useFoodMutation((db, id: string) => foodService.archiveSavedMeal(db, id));
+}
+
+export function useLogFood() {
+  return useFoodMutation((db, args: { date: string; foodId: string; quantity: number }) =>
+    foodService.logFood(db, args.date, args.foodId, args.quantity)
+  );
+}
+
+export function useLogSavedMeal() {
+  return useFoodMutation((db, args: { date: string; savedMealId: string; servings?: number }) =>
+    foodService.logSavedMeal(db, args.date, args.savedMealId, args.servings ?? 1)
+  );
+}
+
+export function useUpdateLogQuantity() {
+  return useFoodMutation((db, args: { id: string; quantity: number }) =>
+    foodService.updateLogQuantity(db, args.id, args.quantity)
+  );
+}
+
+export function useDeleteLogEntry() {
+  return useFoodMutation((db, id: string) => foodService.deleteLogEntry(db, id));
+}

--- a/src/frontend/navigation/TabBar.tsx
+++ b/src/frontend/navigation/TabBar.tsx
@@ -8,6 +8,7 @@ import type { BottomTabBarProps } from '@react-navigation/bottom-tabs';
 
 const TAB_ICONS: Record<string, { active: keyof typeof Ionicons.glyphMap; inactive: keyof typeof Ionicons.glyphMap }> = {
   index: { active: 'home', inactive: 'home-outline' },
+  food: { active: 'restaurant', inactive: 'restaurant-outline' },
   workouts: { active: 'time', inactive: 'time-outline' },
   calendar: { active: 'calendar', inactive: 'calendar-outline' },
   exercises: { active: 'barbell', inactive: 'barbell-outline' },

--- a/src/shared/constants/macros.ts
+++ b/src/shared/constants/macros.ts
@@ -1,0 +1,15 @@
+/** Macro display constants - colors and labels. Protein uses the app's primary accent (priority macro). */
+export const MACRO_COLORS = {
+  calories: 'rgb(250, 250, 250)', // headline / neutral
+  protein: 'rgb(52, 211, 153)', // primary green — the priority macro
+  carbs: 'rgb(96, 165, 250)', // blue
+  fat: 'rgb(251, 146, 60)', // orange
+} as const;
+
+export const MACRO_OVER_COLOR = 'rgb(248, 113, 113)'; // red — over target
+
+export const SERVING_UNITS: { label: string; value: 'g' | 'ml' | 'unit' }[] = [
+  { label: 'g', value: 'g' },
+  { label: 'ml', value: 'ml' },
+  { label: 'unit', value: 'unit' },
+];

--- a/src/shared/types/food.ts
+++ b/src/shared/types/food.ts
@@ -1,0 +1,101 @@
+/** Food & macro tracking types - foods, saved meals, and daily log entries. */
+
+export type ServingUnit = 'g' | 'ml' | 'unit';
+export type SavedMealKind = 'composed' | 'manual';
+export type FoodLogEntryType = 'food' | 'meal';
+
+/** The four tracked macros. Calories are kcal; protein/carbs/fat are grams. */
+export interface Macros {
+  calories: number;
+  proteinG: number;
+  carbsG: number;
+  fatG: number;
+}
+
+/** A food with macros defined per `servingSize` of `servingUnit` (e.g. per 100 g). */
+export interface FoodItem {
+  id: string;
+  name: string;
+  servingSize: number;
+  servingUnit: ServingUnit;
+  calories: number;
+  proteinG: number;
+  carbsG: number;
+  fatG: number;
+  archivedAt: string | null;
+  createdAt: string;
+}
+
+export interface FoodItemInput {
+  name: string;
+  servingSize: number;
+  servingUnit: ServingUnit;
+  calories: number;
+  proteinG: number;
+  carbsG: number;
+  fatG: number;
+}
+
+/** One food + quantity within a composed saved meal. `food` is joined in for display/compute. */
+export interface SavedMealItem {
+  id: string;
+  savedMealId: string;
+  foodId: string;
+  quantity: number; // amount in the food's servingUnit
+  position: number;
+  food?: FoodItem;
+}
+
+/** A named, reusable meal: either composed of foods, or a manual fixed macro total. */
+export interface SavedMeal {
+  id: string;
+  name: string;
+  kind: SavedMealKind;
+  // Only populated (and authoritative) when kind === 'manual'.
+  calories: number | null;
+  proteinG: number | null;
+  carbsG: number | null;
+  fatG: number | null;
+  archivedAt: string | null;
+  createdAt: string;
+}
+
+/** A saved meal with its resolved per-serving totals (and items, for composed meals). */
+export interface SavedMealWithTotals extends SavedMeal {
+  totals: Macros;
+  items: SavedMealItem[]; // empty for manual meals
+}
+
+/** Input for creating/updating a saved meal. For 'composed', pass items; for 'manual', pass totals. */
+export interface SavedMealInput {
+  name: string;
+  kind: SavedMealKind;
+  totals?: Macros; // required for 'manual'
+  items?: { foodId: string; quantity: number }[]; // required for 'composed'
+}
+
+/** A food or saved meal logged to a date, with a snapshot of the resolved (scaled) macros. */
+export interface FoodLogEntry {
+  id: string;
+  date: string; // YYYY-MM-DD
+  entryType: FoodLogEntryType;
+  foodId: string | null;
+  savedMealId: string | null;
+  quantity: number; // food: amount in servingUnit · meal: number of servings
+  name: string;
+  calories: number;
+  proteinG: number;
+  carbsG: number;
+  fatG: number;
+  createdAt: string;
+}
+
+export interface DailyTotals extends Macros {
+  entryCount: number;
+}
+
+/** Per-install daily macro targets (stored in the settings key/value table). */
+export interface MacroTargets {
+  dailyCalorieTarget: number;
+  dailyProteinTarget: number;
+}

--- a/src/shared/types/settings.ts
+++ b/src/shared/types/settings.ts
@@ -4,4 +4,6 @@ export type UnitSystem = 'metric' | 'imperial';
 export interface AppSettings {
   units: UnitSystem;
   defaultRestSeconds: number;
+  dailyCalorieTarget: number;
+  dailyProteinTarget: number;
 }

--- a/src/shared/utils/formatting.ts
+++ b/src/shared/utils/formatting.ts
@@ -127,6 +127,23 @@ export function formatPrescription(
   return `${setPart}${repPart}`;
 }
 
+/** Calories, rounded to a whole number: 507.5 -> "508 kcal". */
+export function formatCalories(kcal: number): string {
+  return `${Math.round(kcal)} kcal`;
+}
+
+/** A macro weight in grams, at most one decimal: 51.94 -> "51.9 g". */
+export function formatGrams(grams: number): string {
+  return `${Number(grams.toFixed(1))} g`;
+}
+
+/** An amount in a food's serving unit: (150,'g') -> "150 g", (1,'unit') -> "1 unit", (2,'unit') -> "2 units". */
+export function formatAmount(quantity: number, unit: 'g' | 'ml' | 'unit'): string {
+  const n = Number(quantity.toFixed(unit === 'unit' ? 2 : 1));
+  if (unit === 'unit') return `${n} ${n === 1 ? 'unit' : 'units'}`;
+  return `${n} ${unit}`;
+}
+
 export function formatCompactNumber(value: number): string {
   const abs = Math.abs(value);
   const sign = value < 0 ? '-' : '';


### PR DESCRIPTION
## Summary
A per-install **food & macro tracker** — a new **Food** tab for logging meals against daily calorie/protein targets. Favors fast logging of repeated meals (one-tap saved meals) over a comprehensive food database, per the brief.

Since the app is one local SQLite DB per install (no auth), "per-user" is realized as **per-install** — no `user_id`, and per-user targets live in the existing `settings` table. No seeded/personal meals in the codebase (seed your own via adb). Deferred: in-app multi-profile (#42), trailing-7-day bodyweight rolling average (#43). Bodyweight is otherwise untouched.

## Data model (migration `v19 → v20`, all un-scoped)
- **`food_items`** — per-serving macros (`serving_size`/`serving_unit` + calories/protein/carbs/fat), `archived_at` soft-delete.
- **`saved_meals`** — reusable meal, explicit `kind`: `composed` (of foods) or `manual` (fixed totals).
- **`saved_meal_items`** — composed-meal components (FK→saved_meals `ON DELETE CASCADE`, FK→food_items, quantity, position).
- **`food_log_entries`** — a food/meal logged to a date; **snapshots** resolved+scaled macros at log time (like `workout_sets` store literal weight/reps) so history is immutable and daily totals are a plain `SUM`.

## Layers (matches repo conventions)
models `foodItem`/`savedMeal`/`foodLog` → `foodService` (composed-total computation, snapshot logging, validation) → `useFood` hooks (keyed `['food']`, mutations invalidate the prefix) → `settingsStore` targets → **Food** tab (`app/(tabs)/food.tsx`) + management screens (`app/food/{foods,meals}.tsx`) + overlays (`src/frontend/components/food/`).

## UX
Daily view shows remaining calories + **remaining protein prominently and visually distinct** (green — the priority macro), running totals for all macros, one-tap quick-add of saved meals, and an editable/deletable log with per-day navigation.

## Testing
- **SQL replay** (`sqlite3`): composed-meal totals, daily SUM, cascade, and snapshot-survives-meal-delete verified.
- **`tsc --noEmit`**: clean.
- **Full E2E on the Android emulator** (release APK): v19→v20 migrated in-place preserving existing data; created a food → logged it (remaining updated) → deleted (reset); built a composed meal (Chicken 200 g → 330 kcal / 62 P computed live); **one-tap logged the saved meal → totals & remaining updated**. No crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)