### PR TITLE
feat(food): idempotent JSON import for foods, meals & targets

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -12,6 +12,7 @@ import { WeeklyAverages } from '@frontend/components/profile/WeeklyAverages';
 import { GymManager } from '@frontend/components/profile/GymManager';
 import { SelectPicker } from '@frontend/components/overlay/SelectPicker';
 import { WeightHistorySheet } from '@frontend/components/overlay/WeightHistorySheet';
+import { ImportSheet } from '@frontend/components/food/ImportSheet';
 import type { UnitSystem } from '@shared/types/settings';
 
 const RELEASES_URL = 'https://github.com/leonx03/vext/releases';
@@ -44,6 +45,7 @@ export default function ProfileScreen() {
   const [weightInput, setWeightInput] = useState('');
   const [weightError, setWeightError] = useState<string | null>(null);
   const [showWeightHistory, setShowWeightHistory] = useState(false);
+  const [showImport, setShowImport] = useState(false);
 
   const { data: weightHistory } = useBodyWeightHistory();
   const { data: weeklyAverages } = useBodyWeightWeeklyAverages(8);
@@ -188,6 +190,24 @@ export default function ProfileScreen() {
           </Pressable>
         </View>
 
+        {/* Data */}
+        <View className="mx-4 mt-3 rounded-xl bg-background-50 p-4">
+          <Text className="text-sm font-medium text-foreground-muted mb-3">Data</Text>
+          <Pressable
+            onPress={() => setShowImport(true)}
+            className="flex-row items-center justify-between"
+          >
+            <View className="flex-row items-center gap-2">
+              <Ionicons name="download-outline" size={20} color="rgb(163, 163, 163)" />
+              <Text className="text-base text-foreground">Import from JSON</Text>
+            </View>
+            <Ionicons name="chevron-forward" size={16} color="rgb(163, 163, 163)" />
+          </Pressable>
+          <Text className="mt-2 text-xs text-foreground-subtle">
+            Bulk-add foods, saved meals, and targets. Safe to run more than once.
+          </Text>
+        </View>
+
         {/* About */}
         <View className="mx-4 mt-3 rounded-xl bg-background-50 p-4">
           <Text className="text-sm font-medium text-foreground-muted mb-3">About</Text>
@@ -221,6 +241,8 @@ export default function ProfileScreen() {
         onDelete={(id) => deleteWeight.mutate(id)}
         onClose={() => setShowWeightHistory(false)}
       />
+
+      <ImportSheet visible={showImport} onClose={() => setShowImport(false)} />
     </View>
   );
 }

--- a/src/backend/models/foodItem.ts
+++ b/src/backend/models/foodItem.ts
@@ -36,6 +36,16 @@ export async function getById(db: SQLite.SQLiteDatabase, id: string): Promise<Fo
   return row ? mapRow(row) : null;
 }
 
+/** Find an active (non-archived) food by name, case-insensitive. Used for idempotent import. */
+export async function getByName(db: SQLite.SQLiteDatabase, name: string): Promise<FoodItem | null> {
+  const row = await db.getFirstAsync<FoodItemRow>(
+    `SELECT * FROM food_items WHERE name = ? COLLATE NOCASE AND archived_at IS NULL
+     ORDER BY created_at ASC LIMIT 1`,
+    name
+  );
+  return row ? mapRow(row) : null;
+}
+
 /** All foods, alphabetical. Excludes archived unless requested. */
 export async function getAll(
   db: SQLite.SQLiteDatabase,

--- a/src/backend/models/savedMeal.ts
+++ b/src/backend/models/savedMeal.ts
@@ -34,6 +34,16 @@ export async function getById(db: SQLite.SQLiteDatabase, id: string): Promise<Sa
   return row ? mapRow(row) : null;
 }
 
+/** Find an active (non-archived) saved meal by name, case-insensitive. Used for idempotent import. */
+export async function getByName(db: SQLite.SQLiteDatabase, name: string): Promise<SavedMeal | null> {
+  const row = await db.getFirstAsync<SavedMealRow>(
+    `SELECT * FROM saved_meals WHERE name = ? COLLATE NOCASE AND archived_at IS NULL
+     ORDER BY created_at ASC LIMIT 1`,
+    name
+  );
+  return row ? mapRow(row) : null;
+}
+
 export async function getAll(
   db: SQLite.SQLiteDatabase,
   includeArchived = false

--- a/src/backend/services/importService.ts
+++ b/src/backend/services/importService.ts
@@ -1,0 +1,171 @@
+/** Import service - idempotent JSON import of personal foods, saved meals, and daily targets. */
+import type * as SQLite from 'expo-sqlite';
+import * as foodItemModel from '@backend/models/foodItem';
+import * as savedMealModel from '@backend/models/savedMeal';
+import type { ImportMeal, ImportPayload, ImportResult, ServingUnit } from '@shared/types/food';
+
+const SERVING_UNITS: ServingUnit[] = ['g', 'ml', 'unit'];
+
+function isNum(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v);
+}
+
+function validate(payload: ImportPayload): void {
+  const foods = payload.foods ?? [];
+  const meals = payload.meals ?? [];
+
+  foods.forEach((f, i) => {
+    if (!f || typeof f.name !== 'string' || !f.name.trim()) throw new Error(`Food #${i + 1}: missing name`);
+    const serving = f.serving ?? 100;
+    if (!(isNum(serving) && serving > 0)) throw new Error(`Food "${f.name}": invalid serving`);
+    if (f.unit != null && !SERVING_UNITS.includes(f.unit)) {
+      throw new Error(`Food "${f.name}": unit must be g, ml, or unit`);
+    }
+    for (const [k, v] of [
+      ['calories', f.calories],
+      ['protein', f.protein],
+      ['carbs', f.carbs],
+      ['fat', f.fat],
+    ] as const) {
+      if (!(isNum(v) && v >= 0)) throw new Error(`Food "${f.name}": invalid ${k}`);
+    }
+  });
+
+  meals.forEach((m, i) => {
+    if (!m || typeof m.name !== 'string' || !m.name.trim()) throw new Error(`Meal #${i + 1}: missing name`);
+    if (isComposed(m)) {
+      m.components!.forEach((c) => {
+        if (!c || typeof c.food !== 'string' || !c.food.trim() || !(isNum(c.amount) && c.amount > 0)) {
+          throw new Error(`Meal "${m.name}": each component needs a food name and a positive amount`);
+        }
+      });
+    } else {
+      for (const [k, v] of [
+        ['calories', m.calories],
+        ['protein', m.protein],
+        ['carbs', m.carbs],
+        ['fat', m.fat],
+      ] as const) {
+        if (!(isNum(v) && v >= 0)) throw new Error(`Meal "${m.name}": needs components or a valid ${k}`);
+      }
+    }
+  });
+
+  if (payload.targets) {
+    if (!(isNum(payload.targets.calories) && payload.targets.calories >= 0)) throw new Error('Invalid calorie target');
+    if (!(isNum(payload.targets.protein) && payload.targets.protein >= 0)) throw new Error('Invalid protein target');
+  }
+}
+
+function isComposed(m: ImportMeal): boolean {
+  return Array.isArray(m.components) && m.components.length > 0;
+}
+
+/**
+ * Parse + apply a personal seed JSON. Idempotent: foods and meals are matched by name
+ * (case-insensitive) and updated in place, so re-running never creates duplicates. Runs in a
+ * single transaction — a bad reference (e.g. a meal component naming a food that doesn't exist)
+ * aborts the whole import with a clear message and leaves data untouched.
+ */
+export async function importFromJson(db: SQLite.SQLiteDatabase, text: string): Promise<ImportResult> {
+  let payload: ImportPayload;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    throw new Error('Invalid JSON — check the syntax');
+  }
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error('JSON must be an object with foods / meals / targets');
+  }
+  validate(payload);
+
+  const foods = payload.foods ?? [];
+  const meals = payload.meals ?? [];
+  const result: ImportResult = {
+    foodsCreated: 0,
+    foodsUpdated: 0,
+    mealsCreated: 0,
+    mealsUpdated: 0,
+    targetsSet: false,
+  };
+
+  await db.withTransactionAsync(async () => {
+    // Foods (upsert by name); remember the resolved id per name for meal components.
+    const idByName = new Map<string, string>();
+    for (const f of foods) {
+      const input = {
+        name: f.name.trim(),
+        servingSize: f.serving ?? 100,
+        servingUnit: (f.unit ?? 'g') as ServingUnit,
+        calories: f.calories,
+        proteinG: f.protein,
+        carbsG: f.carbs,
+        fatG: f.fat,
+      };
+      const existing = await foodItemModel.getByName(db, input.name);
+      if (existing) {
+        await foodItemModel.update(db, existing.id, input);
+        idByName.set(input.name.toLowerCase(), existing.id);
+        result.foodsUpdated++;
+      } else {
+        const created = await foodItemModel.create(db, input);
+        idByName.set(input.name.toLowerCase(), created.id);
+        result.foodsCreated++;
+      }
+    }
+
+    // Meals (upsert by name).
+    for (const m of meals) {
+      const name = m.name.trim();
+      const composed = isComposed(m);
+      const items: { foodId: string; quantity: number }[] = [];
+      if (composed) {
+        for (const c of m.components!) {
+          const key = c.food.trim().toLowerCase();
+          let foodId = idByName.get(key);
+          if (!foodId) {
+            const pre = await foodItemModel.getByName(db, c.food.trim());
+            if (pre) foodId = pre.id;
+          }
+          if (!foodId) throw new Error(`Meal "${name}" references unknown food "${c.food}"`);
+          items.push({ foodId, quantity: c.amount });
+        }
+      }
+      const args = composed
+        ? { name, kind: 'composed' as const, calories: null, proteinG: null, carbsG: null, fatG: null }
+        : {
+            name,
+            kind: 'manual' as const,
+            calories: m.calories!,
+            proteinG: m.protein!,
+            carbsG: m.carbs!,
+            fatG: m.fat!,
+          };
+      const existing = await savedMealModel.getByName(db, name);
+      if (existing) {
+        await savedMealModel.updateMeal(db, existing.id, args);
+        await savedMealModel.replaceItems(db, existing.id, items);
+        result.mealsUpdated++;
+      } else {
+        const id = await savedMealModel.createMeal(db, args);
+        await savedMealModel.replaceItems(db, id, items);
+        result.mealsCreated++;
+      }
+    }
+
+    // Targets (settings key/value upsert; store is refreshed by the caller).
+    if (payload.targets) {
+      await db.runAsync(
+        `INSERT OR REPLACE INTO settings (key, value) VALUES ('dailyCalorieTarget', ?)`,
+        String(Math.round(payload.targets.calories))
+      );
+      await db.runAsync(
+        `INSERT OR REPLACE INTO settings (key, value) VALUES ('dailyProteinTarget', ?)`,
+        String(Math.round(payload.targets.protein))
+      );
+      result.targetsSet = true;
+    }
+  });
+
+  return result;
+}

--- a/src/frontend/components/food/ImportSheet.tsx
+++ b/src/frontend/components/food/ImportSheet.tsx
@@ -1,0 +1,80 @@
+/** ImportSheet - full-screen modal to paste a personal seed JSON and import foods/meals/targets. */
+import React, { useState, useEffect } from 'react';
+import { Modal, View, Text, TextInput, Pressable, ScrollView } from 'react-native';
+import { useImportSeed } from '@frontend/hooks/useFood';
+
+type ImportSheetProps = {
+  visible: boolean;
+  onClose: () => void;
+};
+
+export function ImportSheet({ visible, onClose }: ImportSheetProps) {
+  const [text, setText] = useState('');
+  const importSeed = useImportSeed();
+
+  useEffect(() => {
+    if (visible) {
+      setText('');
+      importSeed.reset();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible]);
+
+  const result = importSeed.data;
+
+  const handleImport = () => {
+    if (!text.trim() || importSeed.isPending) return;
+    importSeed.mutate(text);
+  };
+
+  return (
+    <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
+      <View className="flex-1 bg-background">
+        <View className="flex-row items-center justify-between border-b border-background-100 px-4 pb-3 pt-14">
+          <Pressable onPress={onClose} className="py-1">
+            <Text className="text-base text-foreground-muted">Close</Text>
+          </Pressable>
+          <Text className="text-lg font-bold text-foreground">Import from JSON</Text>
+          <Pressable onPress={handleImport} disabled={importSeed.isPending} className="py-1">
+            <Text className="text-base font-semibold text-primary">{importSeed.isPending ? '…' : 'Import'}</Text>
+          </Pressable>
+        </View>
+
+        <ScrollView className="flex-1" contentContainerClassName="px-4 py-4 pb-10">
+          <Text className="text-sm text-foreground-muted mb-3">
+            Paste a JSON object with optional "foods", "meals", and "targets". Items are matched by
+            name and updated in place — safe to run more than once.
+          </Text>
+          <TextInput
+            className="min-h-[240px] rounded-xl bg-background-50 px-4 py-3 text-sm text-foreground"
+            placeholder={'{\n  "foods": [ … ],\n  "meals": [ … ],\n  "targets": { "calories": 2000, "protein": 165 }\n}'}
+            placeholderTextColor="rgb(115, 115, 115)"
+            value={text}
+            onChangeText={setText}
+            multiline
+            textAlignVertical="top"
+            autoCapitalize="none"
+            autoCorrect={false}
+          />
+
+          {importSeed.error && (
+            <Text className="mt-3 text-sm text-destructive">{(importSeed.error as Error).message}</Text>
+          )}
+
+          {result && (
+            <View className="mt-4 rounded-xl bg-background-50 p-4">
+              <Text className="text-sm font-semibold text-primary mb-1">Import complete</Text>
+              <Text className="text-sm text-foreground">
+                Foods: {result.foodsCreated} added, {result.foodsUpdated} updated
+              </Text>
+              <Text className="text-sm text-foreground">
+                Meals: {result.mealsCreated} added, {result.mealsUpdated} updated
+              </Text>
+              {result.targetsSet && <Text className="text-sm text-foreground">Daily targets updated</Text>}
+            </View>
+          )}
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+}

--- a/src/frontend/hooks/useFood.ts
+++ b/src/frontend/hooks/useFood.ts
@@ -1,7 +1,9 @@
 /** Food hooks - React Query queries and mutations for foods, saved meals, and daily logging. */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import * as foodService from '@backend/services/foodService';
+import * as importService from '@backend/services/importService';
 import { useDatabase } from '@frontend/hooks/useDatabase';
+import { useSettingsStore } from '@backend/store/settingsStore';
 import type { FoodItemInput, SavedMealInput } from '@shared/types/food';
 
 // ---- Queries ----------------------------------------------------------------
@@ -98,4 +100,18 @@ export function useUpdateLogQuantity() {
 
 export function useDeleteLogEntry() {
   return useFoodMutation((db, id: string) => foodService.deleteLogEntry(db, id));
+}
+
+/** Import personal foods/meals/targets from a JSON string (idempotent upsert). */
+export function useImportSeed() {
+  const db = useDatabase();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (json: string) => importService.importFromJson(db, json),
+    onSuccess: async () => {
+      queryClient.invalidateQueries({ queryKey: ['food'] });
+      // Refresh the settings store so any imported targets show immediately.
+      await useSettingsStore.getState().loadSettings(db);
+    },
+  });
 }

--- a/src/shared/types/food.ts
+++ b/src/shared/types/food.ts
@@ -99,3 +99,47 @@ export interface MacroTargets {
   dailyCalorieTarget: number;
   dailyProteinTarget: number;
 }
+
+// ---- JSON import (personal seed data) --------------------------------------
+// Human-writable shapes used by the "Import from JSON" feature. Macros use plain
+// keys (protein/carbs/fat) rather than the internal *G suffix for readability.
+
+export interface ImportFood {
+  name: string;
+  serving?: number; // defaults to 100
+  unit?: ServingUnit; // defaults to 'g'
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+}
+
+export interface ImportMealComponent {
+  food: string; // references an ImportFood.name (or an existing food)
+  amount: number; // in the referenced food's serving unit
+}
+
+export interface ImportMeal {
+  name: string;
+  /** Present => composed meal built from these components. */
+  components?: ImportMealComponent[];
+  /** Present (and no components) => manual fixed-total meal. */
+  calories?: number;
+  protein?: number;
+  carbs?: number;
+  fat?: number;
+}
+
+export interface ImportPayload {
+  targets?: { calories: number; protein: number };
+  foods?: ImportFood[];
+  meals?: ImportMeal[];
+}
+
+export interface ImportResult {
+  foodsCreated: number;
+  foodsUpdated: number;
+  mealsCreated: number;
+  mealsUpdated: number;
+  targetsSet: boolean;
+}


### PR DESCRIPTION
## Summary
Adds a **"Import from JSON"** mechanism (Profile → Data) so personal foods, saved meals, and daily targets can be bulk-added by pasting a JSON object. This keeps personal seed data **out of the shipped app** — the feature ships, the data is whatever the user pastes.

## Format
```json
{ "targets": { "calories": 2000, "protein": 165 },
  "foods": [ { "name": "Havermeel", "serving": 100, "unit": "g", "calories": 380, "protein": 13, "carbs": 60, "fat": 7.5 } ],
  "meals": [ { "name": "Office lunch", "components": [ { "food": "Pistolet", "amount": 1 } ] },
             { "name": "3 eieren", "calories": 200, "protein": 18, "carbs": 1, "fat": 14 } ] }
```
A meal with `components` is composed (references foods by name); one with macros is a fixed-total meal.

## Behaviour
- **Idempotent**: foods and meals are matched by name (case-insensitive) and updated in place — safe to run repeatedly, no duplicates.
- **Transactional**: the whole import runs in one transaction; a bad reference (e.g. a component naming an unknown food) aborts with a clear message and leaves data untouched.
- Composed components resolve against foods in the same import or already in the DB.
- No new tables (reuses food/meal/settings). App version → v1.11.0.

## Implementation
`importService.importFromJson` (parse + validate + upsert) · `foodItem`/`savedMeal` `getByName` · `useImportSeed` hook (invalidates food queries, refreshes settings store) · `ImportSheet` paste UI · Profile "Data" section.

## Testing
- **`tsc`** clean.
- **SQL replay**: case-insensitive upsert-by-name → no duplicates; composed-total query correct; unit foods scale correctly.
- **Emulator E2E**: pasted a multi-item payload → foods + composed meal (Avondsnack derived **217 / 41** ✓) + manual meal + targets (protein → 165 ✓); **re-import → 0 added / 2 updated** (idempotent); invalid JSON → clear inline error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)