### PR TITLE
1.11.1 — agenda gym prompt, workout history, body-weight widget, quick meal edit

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "Vext Dev",
     "slug": "vext",
     "scheme": "vext",
-    "version": "1.11.0",
+    "version": "1.11.1",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -12,6 +12,7 @@ import {
   useStartScheduledWorkout,
 } from '@frontend/hooks/useScheduledWorkouts';
 import { parseUTCTimestamp, formatDuration } from '@shared/utils/formatting';
+import { useGymGate } from '@frontend/hooks/useGymGate';
 import { ConfirmDialog } from '@frontend/components/overlay/ConfirmDialog';
 import type { WorkoutSummary } from '@shared/types/workout';
 import type { ScheduledWorkout } from '@shared/types/scheduledWorkout';
@@ -51,6 +52,7 @@ export default function AgendaScreen() {
   const scheduleWorkout = useScheduleWorkout();
   const cancelScheduled = useCancelScheduledWorkout();
   const startScheduled = useStartScheduledWorkout();
+  const { gate, gymGate } = useGymGate();
 
   const isLoading = workoutsLoading || scheduledLoading;
 
@@ -95,13 +97,15 @@ export default function AgendaScreen() {
     setSelectedDate(null);
   };
 
-  const handleStartScheduled = async (s: ScheduledWorkout) => {
-    try {
-      const workout = await startScheduled.mutateAsync({ scheduledId: s.id, seriesId: s.seriesId });
-      router.replace(`/workout/${workout.id}`);
-    } catch (e) {
-      if (__DEV__) console.warn('Start scheduled workout failed:', e);
-    }
+  const handleStartScheduled = (s: ScheduledWorkout) => {
+    gate(async (gymId) => {
+      try {
+        const workout = await startScheduled.mutateAsync({ scheduledId: s.id, seriesId: s.seriesId, gymId });
+        router.replace(`/workout/${workout.id}`);
+      } catch (e) {
+        if (__DEV__) console.warn('Start scheduled workout failed:', e);
+      }
+    });
   };
 
   const handleSchedule = (seriesId: string) => {
@@ -357,6 +361,8 @@ export default function AgendaScreen() {
         }}
         onCancel={() => setCancelTarget(null)}
       />
+
+      {gymGate}
     </View>
   );
 }

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -66,7 +66,8 @@ export default function HomeScreen() {
   });
 
   const { data: weightTrend } = useBodyWeightTrend(30);
-  const { data: weeklyAverages } = useBodyWeightWeeklyAverages(8);
+  // All weeks (not just the latest 8) so navigating the selector back far still resolves an average.
+  const { data: weeklyAverages } = useBodyWeightWeeklyAverages();
 
   const { data: weeklyPRCount } = useQuery({
     queryKey: ['weeklyPRCount', weekOffset],
@@ -168,7 +169,7 @@ export default function HomeScreen() {
             <WeightSparkline entries={weightTrend} units={units} />
             {weeklyAverages && weeklyAverages.length > 0 && (
               <View className="mt-4 border-t border-background-100 pt-4">
-                <WeeklyAverages weeks={weeklyAverages} units={units} />
+                <WeeklyAverages weeks={weeklyAverages} units={units} selectedWeekStart={weekStart} />
               </View>
             )}
           </View>

--- a/app/(tabs)/workouts.tsx
+++ b/app/(tabs)/workouts.tsx
@@ -178,13 +178,22 @@ export default function WorkoutsScreen() {
     <View className="flex-1 bg-background">
       <View className="flex-row items-center justify-between px-4 py-3">
         <Text className="text-2xl font-bold text-foreground">Workouts</Text>
-        <Pressable
-          onPress={() => router.push('/splits')}
-          className="flex-row items-center gap-1.5 rounded-lg bg-background-50 px-3 py-2"
-        >
-          <Ionicons name="calendar-outline" size={16} color="rgb(52, 211, 153)" />
-          <Text className="text-sm font-medium text-primary">Splits</Text>
-        </Pressable>
+        <View className="flex-row items-center gap-2">
+          <Pressable
+            onPress={() => router.push('/splits')}
+            className="flex-row items-center gap-1.5 rounded-lg bg-background-50 px-3 py-2"
+          >
+            <Ionicons name="calendar-outline" size={16} color="rgb(52, 211, 153)" />
+            <Text className="text-sm font-medium text-primary">Splits</Text>
+          </Pressable>
+          <Pressable
+            onPress={() => router.push('/history')}
+            className="flex-row items-center gap-1.5 rounded-lg bg-background-50 px-3 py-2"
+          >
+            <Ionicons name="time-outline" size={16} color="rgb(52, 211, 153)" />
+            <Text className="text-sm font-medium text-primary">History</Text>
+          </Pressable>
+        </View>
       </View>
 
       <FlatList

--- a/app/food/meals.tsx
+++ b/app/food/meals.tsx
@@ -31,6 +31,11 @@ export default function MealsScreen() {
 
   const { data: editingMeal } = useSavedMeal(editingId);
 
+  const openEditor = (id: string | null) => {
+    setEditingId(id);
+    setComposerOpen(true);
+  };
+
   const handleSave = (input: SavedMealInput) => {
     if (editingId) updateMeal.mutate({ id: editingId, input });
     else createMeal.mutate(input);
@@ -45,13 +50,7 @@ export default function MealsScreen() {
           <Text className="text-base text-foreground-muted">Back</Text>
         </Pressable>
         <Text className="text-lg font-bold text-foreground">Saved Meals</Text>
-        <Pressable
-          onPress={() => {
-            setEditingId(null);
-            setComposerOpen(true);
-          }}
-          className="py-1"
-        >
+        <Pressable onPress={() => openEditor(null)} className="py-1">
           <Ionicons name="add" size={24} color="rgb(52, 211, 153)" />
         </Pressable>
       </View>
@@ -67,13 +66,7 @@ export default function MealsScreen() {
         }
         renderItem={({ item }) => (
           <View className="flex-row items-center justify-between rounded-xl bg-background-50 px-4 py-3 mb-2">
-            <Pressable
-              className="flex-1 pr-3"
-              onPress={() => {
-                setEditingId(item.id);
-                setComposerOpen(true);
-              }}
-            >
+            <Pressable className="flex-1 pr-3" onPress={() => openEditor(item.id)}>
               <View className="flex-row items-center gap-2">
                 <Text className="text-base text-foreground">{item.name}</Text>
                 <View className="rounded bg-background-100 px-1.5 py-0.5">
@@ -88,9 +81,24 @@ export default function MealsScreen() {
                 {formatGrams(item.totals.carbsG)} · F {formatGrams(item.totals.fatG)}
               </Text>
             </Pressable>
-            <Pressable onPress={() => setArchiveTarget(item)} className="p-1.5">
-              <Ionicons name="trash-outline" size={16} color="rgb(163, 163, 163)" />
-            </Pressable>
+            <View className="flex-row items-center">
+              <Pressable
+                onPress={() => openEditor(item.id)}
+                hitSlop={6}
+                className="p-1.5"
+                accessibilityLabel={`Edit ${item.name}`}
+              >
+                <Ionicons name="create-outline" size={18} color="rgb(52, 211, 153)" />
+              </Pressable>
+              <Pressable
+                onPress={() => setArchiveTarget(item)}
+                hitSlop={6}
+                className="p-1.5"
+                accessibilityLabel={`Remove ${item.name}`}
+              >
+                <Ionicons name="trash-outline" size={16} color="rgb(163, 163, 163)" />
+              </Pressable>
+            </View>
           </View>
         )}
       />

--- a/app/history/_layout.tsx
+++ b/app/history/_layout.tsx
@@ -1,0 +1,15 @@
+/** History layout - Stack navigator wrapper for the workout history screen. */
+import React from 'react';
+import { Stack } from 'expo-router';
+
+export default function HistoryLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: 'rgb(10, 10, 15)' },
+        animation: 'slide_from_right',
+      }}
+    />
+  );
+}

--- a/app/history/index.tsx
+++ b/app/history/index.tsx
@@ -1,0 +1,162 @@
+/** History screen - every completed workout in reverse-chronological order, with per-session gym assignment. */
+import React, { useMemo, useState } from 'react';
+import { View, Text, Pressable, FlatList, ActivityIndicator, RefreshControl } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { useWorkoutHistoryByDate } from '@frontend/hooks/useHistory';
+import { useSetWorkoutGym } from '@frontend/hooks/useWorkout';
+import { useGyms, useAllGyms } from '@frontend/hooks/useGyms';
+import { SelectPicker } from '@frontend/components/overlay/SelectPicker';
+import { EmptyState } from '@frontend/components/EmptyState';
+import { formatDate, formatDuration, parseUTCTimestamp } from '@shared/utils/formatting';
+import { cn } from '@frontend/lib/utils';
+import type { WorkoutSummary } from '@shared/types/workout';
+
+export default function HistoryScreen() {
+  const router = useRouter();
+  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage, refetch, isRefetching } =
+    useWorkoutHistoryByDate();
+  const setWorkoutGym = useSetWorkoutGym();
+  const { data: activeGyms } = useGyms();
+  const { data: allGyms } = useAllGyms();
+
+  const [gymPickerFor, setGymPickerFor] = useState<WorkoutSummary | null>(null);
+
+  // Resolve gym names including archived ones, so old sessions still show a label.
+  const gymNames = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const g of allGyms ?? []) map.set(g.id, g.name);
+    return map;
+  }, [allGyms]);
+
+  const workouts = useMemo(() => data?.pages.flatMap((page) => page) ?? [], [data]);
+
+  const gymOptions = useMemo(
+    () => (activeGyms ?? []).map((g) => ({ label: g.name, value: g.id })),
+    [activeGyms]
+  );
+
+  const sessionDuration = (w: WorkoutSummary): number =>
+    w.elapsedSeconds > 0
+      ? w.elapsedSeconds
+      : w.completedAt
+        ? Math.floor(
+            (parseUTCTimestamp(w.completedAt).getTime() - parseUTCTimestamp(w.startedAt).getTime()) / 1000
+          )
+        : 0;
+
+  return (
+    <View className="flex-1 bg-background">
+      {/* Header */}
+      <View className="flex-row items-center gap-2 px-4 py-3">
+        <Pressable onPress={() => router.back()} className="p-1">
+          <Ionicons name="chevron-back" size={24} color="rgb(163, 163, 163)" />
+        </Pressable>
+        <Text className="text-2xl font-bold text-foreground">History</Text>
+      </View>
+
+      <FlatList
+        data={workouts}
+        keyExtractor={(item) => item.id}
+        className="flex-1 px-4"
+        contentContainerClassName={cn(workouts.length === 0 ? 'flex-1' : 'pb-[100px]')}
+        refreshControl={
+          <RefreshControl refreshing={isRefetching} onRefresh={refetch} tintColor="rgb(52, 211, 153)" />
+        }
+        onEndReached={() => {
+          if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+        }}
+        onEndReachedThreshold={0.3}
+        ListEmptyComponent={
+          isLoading ? (
+            <View className="flex-1 items-center justify-center">
+              <ActivityIndicator color="rgb(52, 211, 153)" />
+            </View>
+          ) : (
+            <EmptyState
+              icon="time-outline"
+              title="No workouts yet"
+              message="Completed workouts show up here, newest first"
+            />
+          )
+        }
+        ListFooterComponent={
+          isFetchingNextPage ? (
+            <View className="py-4 items-center">
+              <ActivityIndicator color="rgb(52, 211, 153)" />
+            </View>
+          ) : null
+        }
+        renderItem={({ item }) => {
+          const gymName = item.gymId ? gymNames.get(item.gymId) ?? null : null;
+          const isUpdating = setWorkoutGym.isPending && setWorkoutGym.variables?.workoutId === item.id;
+          return (
+            <View className="mb-2 rounded-xl bg-background-50 p-4">
+              <View className="flex-row items-start justify-between mb-2">
+                <View className="flex-1 pr-2">
+                  <Text className="text-sm font-semibold text-foreground">
+                    {formatDate(item.startedAt)}
+                  </Text>
+                  <Text className="text-base font-semibold text-foreground mt-0.5">
+                    {item.name || item.workoutTypeName}
+                  </Text>
+                </View>
+                <View className="rounded-md bg-primary/15 px-2 py-1">
+                  <Text className="text-xs font-medium text-primary">{item.workoutTypeName}</Text>
+                </View>
+              </View>
+
+              <View className="flex-row gap-4 mb-3">
+                <View className="flex-row items-center gap-1">
+                  <Ionicons name="time-outline" size={13} color="rgb(163, 163, 163)" />
+                  <Text className="text-xs text-foreground-muted">{formatDuration(sessionDuration(item))}</Text>
+                </View>
+                <View className="flex-row items-center gap-1">
+                  <Ionicons name="barbell-outline" size={13} color="rgb(163, 163, 163)" />
+                  <Text className="text-xs text-foreground-muted">{item.exerciseCount} exercises</Text>
+                </View>
+                <View className="flex-row items-center gap-1">
+                  <Ionicons name="layers-outline" size={13} color="rgb(163, 163, 163)" />
+                  <Text className="text-xs text-foreground-muted">{item.setCount} sets</Text>
+                </View>
+              </View>
+
+              {/* Gym assignment — tap to set or change */}
+              <Pressable
+                onPress={() => setGymPickerFor(item)}
+                disabled={isUpdating || gymOptions.length === 0}
+                className={cn(
+                  'flex-row items-center gap-1.5 self-start rounded-lg px-3 py-2',
+                  gymName ? 'bg-background-100' : 'border border-dashed border-background-100'
+                )}
+              >
+                <Ionicons
+                  name="location-outline"
+                  size={14}
+                  color={gymName ? 'rgb(52, 211, 153)' : 'rgb(163, 163, 163)'}
+                />
+                <Text className={cn('text-xs font-medium', gymName ? 'text-primary' : 'text-foreground-muted')}>
+                  {isUpdating ? 'Saving…' : gymName ?? 'Set gym'}
+                </Text>
+                {!isUpdating && (
+                  <Ionicons name="chevron-down" size={12} color="rgb(115, 115, 115)" />
+                )}
+              </Pressable>
+            </View>
+          );
+        }}
+      />
+
+      <SelectPicker
+        visible={gymPickerFor !== null}
+        title="Which gym?"
+        options={gymOptions}
+        selectedValue={gymPickerFor?.gymId ?? undefined}
+        onSelect={(gymId) => {
+          if (gymPickerFor) setWorkoutGym.mutate({ workoutId: gymPickerFor.id, gymId });
+        }}
+        onClose={() => setGymPickerFor(null)}
+      />
+    </View>
+  );
+}

--- a/src/backend/models/workout.ts
+++ b/src/backend/models/workout.ts
@@ -209,3 +209,11 @@ export async function updateName(
 ): Promise<void> {
   await db.runAsync(`UPDATE workouts SET name = ? WHERE id = ?`, name, id);
 }
+
+export async function updateGym(
+  db: SQLite.SQLiteDatabase,
+  id: string,
+  gymId: string | null
+): Promise<void> {
+  await db.runAsync(`UPDATE workouts SET gym_id = ? WHERE id = ?`, gymId ?? null, id);
+}

--- a/src/backend/services/workoutService.ts
+++ b/src/backend/services/workoutService.ts
@@ -353,7 +353,8 @@ export async function getFullWorkout(
 export async function getWorkoutSummaries(
   db: SQLite.SQLiteDatabase,
   limit: number,
-  offset: number
+  offset: number,
+  orderBy: 'series' | 'date' = 'series'
 ): Promise<WorkoutSummary[]> {
   type SummaryRow = {
     id: string;
@@ -394,7 +395,9 @@ export async function getWorkoutSummaries(
      LEFT JOIN workout_sets ws ON ws.workout_exercise_id = we.id
      WHERE w.status = ?
      GROUP BY w.id
-     ORDER BY ws_series.sort_order DESC, ws_series.created_at DESC, w.started_at DESC
+     ${orderBy === 'date'
+       ? 'ORDER BY w.completed_at DESC, w.started_at DESC'
+       : 'ORDER BY ws_series.sort_order DESC, ws_series.created_at DESC, w.started_at DESC'}
      LIMIT ? OFFSET ?`,
     WorkoutStatus.Completed,
     limit,
@@ -584,6 +587,15 @@ export async function updateWorkoutSeriesName(
   const w = await workout.getById(db, workoutId);
   if (!w?.seriesId) throw new Error('Workout has no associated series');
   return workoutSeriesModel.updateName(db, w.seriesId, name);
+}
+
+/** Assign (or clear) the gym a completed workout was done at — lets users backfill a missed gym. */
+export async function setWorkoutGym(
+  db: SQLite.SQLiteDatabase,
+  workoutId: string,
+  gymId: string | null
+): Promise<void> {
+  return workout.updateGym(db, workoutId, gymId);
 }
 
 export async function moveSeriesUp(

--- a/src/frontend/components/food/MealComposerSheet.tsx
+++ b/src/frontend/components/food/MealComposerSheet.tsx
@@ -33,8 +33,12 @@ export function MealComposerSheet({ visible, meal, foods, onSave, onClose }: Mea
   const [fat, setFat] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
+  const [editingItemIndex, setEditingItemIndex] = useState<number | null>(null);
+  const [editQty, setEditQty] = useState('');
+  const [editQtyError, setEditQtyError] = useState<string | null>(null);
 
   const isEditing = !!meal;
+  const editingItem = editingItemIndex != null ? items[editingItemIndex] ?? null : null;
 
   useEffect(() => {
     if (!visible) return;
@@ -56,7 +60,24 @@ export function MealComposerSheet({ visible, meal, foods, onSave, onClose }: Mea
       setFat('');
     }
     setError(null);
+    setEditingItemIndex(null);
   }, [visible, meal]);
+
+  const openQtyEditor = (idx: number) => {
+    setEditQty(String(items[idx].quantity));
+    setEditQtyError(null);
+    setEditingItemIndex(idx);
+  };
+
+  const handleSaveQty = () => {
+    const q = parseNum(editQty);
+    if (!(q > 0)) {
+      setEditQtyError('Enter a valid amount');
+      return;
+    }
+    setItems((prev) => prev.map((it, i) => (i === editingItemIndex ? { ...it, quantity: q } : it)));
+    setEditingItemIndex(null);
+  };
 
   const composedTotals: Macros = useMemo(
     () =>
@@ -122,6 +143,11 @@ export function MealComposerSheet({ visible, meal, foods, onSave, onClose }: Mea
       />
     </View>
   );
+
+  const editFood = editingItem?.food ?? null;
+  const editQtyNum = parseNum(editQty);
+  const editFactor =
+    editFood && editFood.servingSize > 0 && editQtyNum > 0 ? editQtyNum / editFood.servingSize : 0;
 
   return (
     <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
@@ -189,13 +215,20 @@ export function MealComposerSheet({ visible, meal, foods, onSave, onClose }: Mea
                         key={`${it.food.id}-${idx}`}
                         className="flex-row items-center justify-between rounded-xl bg-background-50 px-4 py-3"
                       >
-                        <View className="flex-1 pr-3">
-                          <Text className="text-base text-foreground">{it.food.name}</Text>
+                        <Pressable
+                          className="flex-1 pr-3"
+                          onPress={() => openQtyEditor(idx)}
+                          accessibilityLabel={`Edit amount of ${it.food.name}`}
+                        >
+                          <View className="flex-row items-center gap-1.5">
+                            <Text className="text-base text-foreground">{it.food.name}</Text>
+                            <Ionicons name="create-outline" size={13} color="rgb(115, 115, 115)" />
+                          </View>
                           <Text className="text-xs text-foreground-subtle">
                             {formatAmount(it.quantity, it.food.servingUnit)} ·{' '}
                             {formatCalories(it.food.calories * f)} · P {formatGrams(it.food.proteinG * f)}
                           </Text>
-                        </View>
+                        </Pressable>
                         <Pressable onPress={() => setItems((prev) => prev.filter((_, i) => i !== idx))} className="p-1.5">
                           <Ionicons name="close-circle" size={20} color="rgb(163, 163, 163)" />
                         </Pressable>
@@ -247,6 +280,58 @@ export function MealComposerSheet({ visible, meal, foods, onSave, onClose }: Mea
         onPick={(food, quantity) => setItems((prev) => [...prev, { food, quantity }])}
         onClose={() => setPickerOpen(false)}
       />
+
+      {/* Quantity editor for a food already in the meal */}
+      <Modal
+        visible={editingItem !== null}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setEditingItemIndex(null)}
+      >
+        <Pressable className="flex-1 justify-end bg-black/60" onPress={() => setEditingItemIndex(null)}>
+          <Pressable className="rounded-t-2xl bg-background-50 px-6 pb-8 pt-5" onPress={(e) => e.stopPropagation()}>
+            {editFood && (
+              <>
+                <Text className="text-lg font-bold text-foreground">{editFood.name}</Text>
+                <Text className="text-xs text-foreground-subtle mb-4">Edit amount</Text>
+
+                <Text className="text-sm font-medium text-foreground mb-2">
+                  Amount ({editFood.servingUnit})
+                </Text>
+                <TextInput
+                  className="rounded-xl bg-background-100 px-4 py-3 text-base text-foreground"
+                  keyboardType="decimal-pad"
+                  value={editQty}
+                  onChangeText={(t) => {
+                    setEditQty(t);
+                    setEditQtyError(null);
+                  }}
+                  autoFocus
+                />
+                <View className="mt-3 flex-row gap-4">
+                  <Text className="text-sm" style={{ color: MACRO_COLORS.calories }}>
+                    {formatCalories(editFood.calories * editFactor)}
+                  </Text>
+                  <Text className="text-sm" style={{ color: MACRO_COLORS.protein }}>
+                    P {formatGrams(editFood.proteinG * editFactor)}
+                  </Text>
+                  <Text className="text-sm" style={{ color: MACRO_COLORS.carbs }}>
+                    C {formatGrams(editFood.carbsG * editFactor)}
+                  </Text>
+                  <Text className="text-sm" style={{ color: MACRO_COLORS.fat }}>
+                    F {formatGrams(editFood.fatG * editFactor)}
+                  </Text>
+                </View>
+                {editQtyError && <Text className="mt-3 text-xs text-destructive">{editQtyError}</Text>}
+
+                <Pressable onPress={handleSaveQty} className="mt-5 rounded-xl bg-primary py-3 items-center">
+                  <Text className="text-base font-semibold text-background">Save</Text>
+                </Pressable>
+              </>
+            )}
+          </Pressable>
+        </Pressable>
+      </Modal>
     </Modal>
   );
 }

--- a/src/frontend/components/profile/WeeklyAverages.tsx
+++ b/src/frontend/components/profile/WeeklyAverages.tsx
@@ -1,4 +1,4 @@
-/** WeeklyAverages - the current week's average body weight (with week-over-week delta) plus recent weeks. */
+/** WeeklyAverages - the average body weight for a single week (selected or most recent) with a week-over-week delta. */
 import React from 'react';
 import { View, Text } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
@@ -9,14 +9,24 @@ import type { UnitSystem } from '@shared/types/settings';
 type WeeklyAveragesProps = {
   weeks: WeeklyAverageWeight[]; // most recent week first
   units: UnitSystem;
+  /**
+   * Monday-anchored week to display (matches `weekStart`). When omitted, the most recent week
+   * with entries is shown. When set but that week has no entries, an empty state is shown.
+   */
+  selectedWeekStart?: string;
 };
 
-export function WeeklyAverages({ weeks, units }: WeeklyAveragesProps) {
-  if (weeks.length === 0) return null;
+export function WeeklyAverages({ weeks, units, selectedWeekStart }: WeeklyAveragesProps) {
+  const idx = selectedWeekStart
+    ? weeks.findIndex((w) => w.weekStart === selectedWeekStart)
+    : weeks.length > 0
+      ? 0
+      : -1;
+  const current = idx >= 0 ? weeks[idx] : null;
+  // The next entry in the (descending) list is the most recent week before `current` with entries.
+  const previous = idx >= 0 ? weeks[idx + 1] : undefined;
 
-  const [latest, ...rest] = weeks;
-  const previous = rest[0];
-  const deltaKg = previous ? latest.avgWeightKg - previous.avgWeightKg : null;
+  const deltaKg = current && previous ? current.avgWeightKg - previous.avgWeightKg : null;
   // A change under 0.05 kg rounds to "0.0" at one decimal — treat it as flat.
   const isFlat = deltaKg != null && Math.abs(deltaKg) < 0.05;
 
@@ -24,42 +34,31 @@ export function WeeklyAverages({ weeks, units }: WeeklyAveragesProps) {
     <View>
       <Text className="text-xs font-medium text-foreground-muted mb-2">Weekly average</Text>
 
-      {/* Current (latest) week headline + week-over-week change */}
-      <View className="flex-row items-end justify-between">
-        <View>
-          <Text className="text-xs text-foreground-subtle">{formatWeekRange(latest.weekStart)}</Text>
-          <Text className="text-2xl font-bold text-foreground">{formatWeight(latest.avgWeightKg, units)}</Text>
-          <Text className="text-xs text-foreground-subtle">
-            {latest.entryCount} {latest.entryCount === 1 ? 'entry' : 'entries'}
-          </Text>
-        </View>
-
-        {deltaKg != null && (
-          <View className="flex-row items-center gap-1">
-            <Ionicons
-              name={isFlat ? 'remove' : deltaKg > 0 ? 'arrow-up' : 'arrow-down'}
-              size={14}
-              color="rgb(163, 163, 163)"
-            />
-            <Text className="text-sm text-foreground-muted">
-              {isFlat ? 'No change' : `${formatWeight(Math.abs(deltaKg), units)} vs last`}
+      {current ? (
+        <View className="flex-row items-end justify-between">
+          <View>
+            <Text className="text-xs text-foreground-subtle">{formatWeekRange(current.weekStart)}</Text>
+            <Text className="text-2xl font-bold text-foreground">{formatWeight(current.avgWeightKg, units)}</Text>
+            <Text className="text-xs text-foreground-subtle">
+              {current.entryCount} {current.entryCount === 1 ? 'entry' : 'entries'}
             </Text>
           </View>
-        )}
-      </View>
 
-      {/* Prior weeks, each with its own average */}
-      {rest.length > 0 && (
-        <View className="mt-3 gap-1.5">
-          {rest.map((week) => (
-            <View key={week.weekStart} className="flex-row items-center justify-between">
-              <Text className="text-sm text-foreground">{formatWeekRange(week.weekStart)}</Text>
-              <Text className="text-sm font-semibold text-foreground">
-                {formatWeight(week.avgWeightKg, units)}
+          {deltaKg != null && (
+            <View className="flex-row items-center gap-1">
+              <Ionicons
+                name={isFlat ? 'remove' : deltaKg > 0 ? 'arrow-up' : 'arrow-down'}
+                size={14}
+                color="rgb(163, 163, 163)"
+              />
+              <Text className="text-sm text-foreground-muted">
+                {isFlat ? 'No change' : `${formatWeight(Math.abs(deltaKg), units)} vs prior week`}
               </Text>
             </View>
-          ))}
+          )}
         </View>
+      ) : (
+        <Text className="text-sm text-foreground-muted">No entries this week</Text>
       )}
     </View>
   );

--- a/src/frontend/hooks/useHistory.ts
+++ b/src/frontend/hooks/useHistory.ts
@@ -22,6 +22,24 @@ export function useWorkoutHistory() {
   });
 }
 
+/** Flat, purely chronological history (all completed sessions, newest done first). */
+export function useWorkoutHistoryByDate() {
+  const db = useDatabase();
+  const pageSize = APP_CONFIG.defaults.historyPageSize;
+
+  return useInfiniteQuery({
+    queryKey: ['workoutHistoryByDate'],
+    queryFn: ({ pageParam = 0 }) =>
+      workoutService.getWorkoutSummaries(db, pageSize, pageParam, 'date'),
+    getNextPageParam: (lastPage, allPages) => {
+      if (lastPage.length < pageSize) return undefined;
+      return allPages.length * pageSize;
+    },
+    initialPageParam: 0,
+    staleTime: 60 * 1000,
+  });
+}
+
 export function useWorkoutHistoryCount() {
   const db = useDatabase();
   return useQuery({

--- a/src/frontend/hooks/useWorkout.ts
+++ b/src/frontend/hooks/useWorkout.ts
@@ -337,6 +337,22 @@ export function useUpdateWorkoutName() {
   });
 }
 
+export function useSetWorkoutGym() {
+  const db = useDatabase();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ workoutId, gymId }: { workoutId: string; gymId: string | null }) =>
+      workoutService.setWorkoutGym(db, workoutId, gymId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['workoutHistory'] });
+      queryClient.invalidateQueries({ queryKey: ['workoutHistoryByDate'] });
+      queryClient.invalidateQueries({ queryKey: ['workoutGroupDetails'] });
+      queryClient.invalidateQueries({ queryKey: ['workoutsByMonth'] });
+      queryClient.invalidateQueries({ queryKey: ['recentWorkouts'] });
+    },
+  });
+}
+
 export function useMoveSeriesUp() {
   const db = useDatabase();
   const queryClient = useQueryClient();


### PR DESCRIPTION
Patch release **1.11.1** — fixes found after 1.11.0, plus two small requested enhancements. All verified end-to-end on the Android emulator.

## Fixes
- **fix(agenda): prompt for gym when starting a planned workout** — starting a scheduled/split workout from the Agenda bypassed the gym gate, so with 2+ gyms you were never asked which gym and the session fell back to the default (or none). Now routes through `useGymGate` like the new-workout/repeat flows.
- **fix(home): body-weight widget follows the selected week** — the dashboard widget ignored the week selector (always showed the newest week + a list of past weeks). Now it shows only the selected week's average with a "vs prior week" delta, and an empty state when that week has no entries. Profile is simplified to the most recent week the same way.

## Enhancements
- **feat(workouts): History tab with per-session gym assignment** — a "History" pill next to "Splits" opens a chronological list of every completed workout (newest done first). Each row shows the gym it was done at, or a **Set gym** control when none is set (e.g. legacy sessions), which assigns/changes the gym in place.
- **feat(food): quick-edit saved meals** — a visible edit (pencil) button on each saved meal, and tap-to-edit food quantities inside a composed meal (with a live macro preview) instead of remove-and-re-add.

## Verification
Reproduced both bugs, then verified the fixes live on the emulator: the "Which gym?" prompt now appears from the Agenda and the chosen gym flows through; History lists two sessions newest-first and a gym-less session shows **Set gym** → assigning a gym persists (confirmed in SQLite); the body-weight widget tracks the selector across weeks; and the meal edit button + quantity editor open and save. `tsc --noEmit` clean.

No schema change (uses existing `workout_sets`/`custom_fields` columns; adds no migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)