### PR TITLE
1.12.0 — per-exercise tracking types (time & bodyweight) + /e2e-test skill

### DIFF
--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: e2e-test
+description: >
+  Drive the Vext app end-to-end on the Android emulator (or a connected device) and verify the
+  most important user flows plus known edge cases, then report pass/fail. Use when the user runs
+  /e2e-test, or asks to "e2e test", "run the e2e suite", "smoke test the app", "regression test",
+  or verify a change end-to-end on the emulator. Optional arg scopes the run (see Args).
+---
+
+# Vext end-to-end test
+
+Build the app from the **current working tree**, run it on the emulator, drive the real UI, and
+confirm the important flows + edge cases behave correctly. This is manual-style verification of the
+running app — not the (nonexistent) unit-test suite. End state: a clear PASS/FAIL report with
+screenshots of key states and DB confirmations where behavior isn't visible in the UI.
+
+## Args
+
+- `/e2e-test` (no arg) → the **default suite**: all P0 cases + the curated P1 cases + the key edge
+  cases marked ⭐ below. This is "most important cases and edge cases."
+- `/e2e-test full` → every case in this file.
+- `/e2e-test <area>` → only that area, e.g. `basics`, `workouts`, `agenda`, `gyms`, `splits`,
+  `food`, `bodyweight`, `exercise-types`, `history`, `migration`.
+
+Always tell the user up front which cases you're going to run, then work the list and report.
+
+## Golden rules (read first — these are hard-won)
+
+1. **Tap using `mobile_list_elements_on_screen` coordinates, never positions eyeballed from a
+   screenshot.** The screenshot image is scaled down (~928 px wide) but the device is 1080 px and
+   taps use real device px — estimating from the screenshot misses by ~15%. Flow: screenshot to
+   *see* state → `mobile_list_elements_on_screen` to get a target's ViewGroup, tap its **center**.
+2. **RN `<Modal>` text inputs don't focus via synthetic taps on the emulator** (the soft keyboard
+   never shows; `mobile_type_keys` then sends a stray BACK that dismisses the modal). Non-modal
+   inputs (search bars, the workout-screen set fields, the Profile weight field, the gym "Add a
+   gym" field) **do** focus on a normal tap — then `adb shell input text '...'` works (`%s` for
+   spaces). For modal inputs, prefer seeding data via SQL (see below), or the TAB-traversal
+   workaround (`adb shell input keyevent 61` walks focus order), or just skip the typed step and
+   note it. The picker/segmented **buttons** inside modals tap fine — only *text entry* is the
+   problem.
+3. **Confirm the change under test is actually in the build.** The release APK embeds the JS
+   bundle at build time, so always rebuild after code changes before driving.
+4. **A blank/error frame or crash is a FAIL** — report it with the screenshot, don't paper over it.
+5. Leave the app installed/running at the end unless asked otherwise. Report what you did and
+   what you couldn't verify (and why).
+
+## Step 0 — Pre-flight (cheap gate)
+
+```bash
+cd /home/leon/src/vext && pnpm exec tsc --noEmit
+```
+If it fails, stop and report the type errors — no point building a broken bundle.
+
+## Step 1 — Bring up the emulator + app
+
+Package id: `com.anonymous.vext.development`. AVD: `vext`. DB: `files/SQLite/vext.db`.
+
+**Emulator** (skip if `adb devices` already shows `emulator-5554 device`):
+```bash
+cd /tmp && setsid bash -c '~/Android/Sdk/emulator/emulator -avd vext -no-window -no-audio -no-boot-anim -gpu swiftshader_indirect -no-snapshot > /tmp/vext-emu.log 2>&1' &
+# poll for boot (run in background, don't block the turn):
+for i in $(seq 1 90); do [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" = "1" ] && { echo BOOTED; break; }; sleep 3; done
+```
+No AVD? See the `android-emulator-testing` memory (create one by hand — no cmdline-tools installed).
+
+**Build the release APK.** The dev-client/Metro path is blocked (host port 8081 is root-held), so
+always build a release APK with the JS bundle embedded. If `android/` is missing, first run
+`pnpm exec expo prebuild --platform android --clean` (slow). Then, detached (long gradle builds get
+reaped if run in the foreground):
+```bash
+cd /home/leon/src/vext/android
+SENT=/tmp/vext-build.sentinel; rm -f "$SENT"
+setsid bash -c "./gradlew :app:assembleRelease -x lint -x lintVitalRelease -x lintVitalAnalyzeRelease > /tmp/vext-build.log 2>&1; echo \$? > '$SENT'" &
+# poll: while [ ! -f "$SENT" ]; do sleep 5; done ; cat "$SENT" should be 0
+```
+
+**Install + launch** (in-place install preserves data → this also exercises the migration):
+```bash
+adb install -r android/app/build/outputs/apk/release/app-release.apk
+adb shell monkey -p com.anonymous.vext.development -c android.intent.category.LAUNCHER 1
+```
+
+## Step 2 — Driving + inspection toolkit
+
+- **UI:** the `mobile` MCP tools (`mobile_take_screenshot`, `mobile_list_elements_on_screen`,
+  `mobile_click_on_screen_at_coordinates`, `mobile_get_screen_size`). Screen is 1080×2340.
+- **Typing into non-modal fields:** tap it, verify `adb shell dumpsys input_method | grep mInputShown`
+  is `true`, then `adb shell input text 'Some%stext'`; `adb shell input keyevent 67` = backspace.
+- **DB read/seed (needs a debuggable build):** the release APK is not debuggable, so `run-as` fails.
+  To inspect or seed the DB, temporarily add `debuggable true` to the `release {}` block in
+  `android/app/build.gradle` (that dir is gitignored — **revert the edit before finishing**),
+  rebuild, reinstall. There is no on-device `sqlite3`; pull the DB (WAL-safe) and use the host one:
+  ```bash
+  PKG=com.anonymous.vext.development
+  adb exec-out run-as $PKG cat files/SQLite/vext.db      > /tmp/v.db
+  adb exec-out run-as $PKG cat files/SQLite/vext.db-wal  > /tmp/v.db-wal   2>/dev/null
+  adb exec-out run-as $PKG cat files/SQLite/vext.db-shm  > /tmp/v.db-shm   2>/dev/null
+  sqlite3 /tmp/v.db "PRAGMA user_version; SELECT ...;"     # host sqlite3 merges the WAL
+  ```
+  To write back: edit `/tmp/v.db` (run your UPDATEs then `PRAGMA wal_checkpoint(TRUNCATE);`),
+  `adb push` it to `/data/local/tmp`, `run-as $PKG cp` it over `files/SQLite/vext.db`, and
+  `run-as $PKG rm -f files/SQLite/vext.db-wal files/SQLite/vext.db-shm`. Force-stop the app first.
+- **Date-dependent data without root:** `adb shell cmd alarm set-time <epoch_ms>` sets the clock
+  (also `settings put global auto_time 0`); log via the UI (the app reads the live clock at
+  button-press); then restore with `set-time $(date +%s)000` + `auto_time 1` and force-stop +
+  relaunch so the JS re-renders date labels.
+
+See the `android-emulator-testing` memory for the full lore.
+
+---
+
+# The test suite
+
+For each case: set up any preconditions, drive it, screenshot the key state, mark **PASS/FAIL**.
+`[P0]` = critical (default suite). `[P1]` = important (default suite). `⭐` = edge case in the
+default suite. Others run only on `/e2e-test full` or a scoped run.
+
+## App basics / smoke — `basics`
+The fastest sanity pass — catches gross breakage before the deeper cases. Run this first.
+- `[P0]` **Every bottom tab opens** with no crash/blank frame: tap each of **Home, Food, Workouts,
+  Agenda, Exercises, Profile** and confirm its key content renders:
+  - **Home:** greeting, week selector (‹ ›), the stats row (Workouts/Sets/kg), Body Weight card.
+  - **Food:** "Nutrition" header, calories + protein remaining, Quick add, Today's log.
+  - **Workouts:** the series list (or the "No workouts yet" empty state) + the Splits / History pills.
+  - **Agenda:** the month calendar grid + month ‹ › navigation changes the month.
+  - **Exercises:** search box, category filter chips, the exercise list.
+  - **Profile:** body-weight logger, units toggle, Gyms section, Rest Timer, Import, version string.
+- `[P0]` **Bottom-nav switching** keeps state sane (the active tab highlights; going back to a tab
+  doesn't crash).
+- `[P0]` **Core "add" operations work** (the fundamentals to build on later):
+  - Log a body weight on Profile (non-modal field) → it appears in the trend/history.
+  - Add a gym on Profile → it shows in the Gyms list.
+  - Create a custom exercise (Exercises → `+` → name + category + tracking → Save) → it appears in
+    the list and is pickable in a workout.
+- ⭐ **Empty states** render (not blank): no workouts, no saved meals, no splits, no history.
+
+## Migration & launch — `migration`
+- `[P0]` App launches to Home after an in-place install over existing data (no crash/blank).
+- `[P0]` `PRAGMA user_version` equals `APP_CONFIG.database.schemaVersion` in `src/config/app.ts`.
+- ⭐ Prior data survives the upgrade: pre-existing body-weight entries, workout series, gyms, and
+  foods/meals are all still present after the migration.
+- ⭐ New columns backfill sanely (e.g. after v21, existing exercises get `tracking_type='weighted'`).
+
+## Workouts & sets — `workouts`
+- `[P0]` **Start a fresh workout:** Start Workout → New Workout → Strength Training → (gym gate) →
+  add an exercise → log a `kg × reps` set (tap field, `input text`) → Finish → it appears in the
+  Workouts list and in History with the right counts.
+- `[P1]` **Repeat past workout:** clones exercises; goes through the gym gate; lands as a new
+  in-progress session.
+- `[P1]` **Supersets:** Make Superset on an exercise, add a second exercise, log a round, then
+  Ungroup — sets are kept.
+- `[P1]` Rep-goal editing colors reps (under=amber, in-range=green, over=blue); "Last: …" shows the
+  previous session's values for the same series (and is per-gym — see gyms).
+- ⭐ **Single active-workout guard:** starting a second workout while one is in progress prompts
+  "discard & continue" rather than silently creating two.
+- ⭐ Delete the last session in a group closes the detail modal; deleting a group removes it.
+
+## Exercise tracking types — `exercise-types`  (schema v21+)
+- `[P1]` In the exercise editor (Exercises tab → tap an exercise → Edit) the **Tracking** picker
+  offers Weight × reps / Bodyweight / Time and persists the choice (confirm in DB `tracking_type`).
+- `[P0]` **Time exercise** (e.g. set Side Plank → Time): its set row shows a single **Duration (s)**
+  field + a ▶/■ **stopwatch**; the rep-goal badge is hidden. Start the stopwatch, wait, stop → the
+  seconds fill the field and save (DB `duration_seconds` set). History shows "Ns".
+- `[P0]` **Bodyweight exercise** (e.g. set Pull-Up → Bodyweight): its set row shows a free-text
+  **Load** field × **Reps**. Enter a non-numeric load like "green band" + reps → saves
+  (DB `custom_fields = {"load":"green band"}`, `reps` set). History shows "green band × N reps".
+- ⭐ Bodyweight set with load only (no reps) shows just the load; Weight × reps default is
+  unchanged for every other exercise.
+- Time + AMRAP renders "max hold" in prescriptions; the seeded Plank/Side Plank default to Time and
+  Pull-Up/Chin-Up to Bodyweight on a fresh install.
+
+## Gyms & the gym gate — `gyms`  (needs ≥2 active gyms to see the picker)
+- `[P0]` With **≥2 active gyms**, starting a workout (fresh, repeat, or from the Agenda) shows the
+  **"Which gym?"** picker; the chosen gym is stored on the session.
+- ⭐ With **exactly 1 gym**, no picker appears and the session falls back to the default gym.
+- ⭐ **Cancelling** the gym picker (tap backdrop/✕) does **not** start a workout.
+- Manage gyms in Profile: add, rename, archive (the default gym can't be archived).
+- Per-gym memory: "last time" weights/structure resolve from that gym's most recent session; weights
+  do not fall back across gyms.
+
+## Agenda & scheduled starts — `agenda`
+- `[P0]` A planned (split) entry shows on its day with a **Start** button; tapping Start goes
+  **through the gym gate** and instantiates the workout from the series template.
+- ⭐ Starting a planned workout with ≥2 gyms prompts for gym (regression: this used to be skipped).
+- An already-started planned entry shows "Started" (no Start button); Remove cancels a planned one.
+- Scheduling from a day requires at least one completed series ("Complete a workout first…").
+
+## Splits — `splits`
+- `[P1]` Apply a split for N cycles from a start date → the correct number of workout days land on
+  the Agenda on the right weekdays (rest days skipped); "Scheduled N".
+- `[P1]` Clear planned workouts removes the applied entries (net zero).
+- Template preview shows notes, alternatives, AMRAP ("× AMRAP" / time "max hold"), and set counts.
+
+## Workout history — `history`
+- `[P0]` The History screen (Workouts → History pill) lists completed sessions **newest-done
+  first**; empty state when none.
+- `[P1]` **Set gym on a done workout:** a session with a gym shows a chip; tapping it opens the gym
+  picker and changes it (persists in DB).
+- ⭐ A gym-less (legacy `gym_id = NULL`) session shows a dashed **"Set gym"** control; assigning a
+  gym persists. (To create one for the test: SQL-set a completed workout's `gym_id = NULL`.)
+
+## Food & macros — `food`
+- `[P0]` One-tap log a saved meal from Quick add → daily calories/protein remaining update; delete
+  the log entry → totals revert.
+- `[P1]` **Manage meals:** each meal row has a pencil **edit** button (and tapping the row edits);
+  in the composer, tapping a food opens a **quantity editor** with a live macro preview (composed
+  meals); manual-macro meals store fixed totals.
+- ⭐ **Snapshot-on-log:** editing or deleting a food/meal does **not** rewrite past log entries
+  (their macros are snapshotted at log time).
+- Targets (Profile → or Food → Targets) drive the "remaining" numbers; JSON import (Profile → Data)
+  is idempotent (upsert by name).
+
+## Body weight — `bodyweight`
+- `[P0]` Log a weight on Profile → the Home dashboard "Body Weight" widget shows the **selected
+  week's** average and follows the week selector (‹ ›).
+- ⭐ A selected week with no entries shows **"No entries this week"**; the delta reads "vs prior
+  week".
+- Profile shows the most recent week's average (single week, no multi-week list).
+
+---
+
+# Adding new cases later (keep this suite easy to grow)
+
+To add a check, append a bullet to the relevant `## <Area>` section using this shape:
+
+```
+- `[P1]` **Short title:** setup → action → **expected observable result**.
+```
+
+- **Priority tags:** `[P0]` critical happy path (in default suite) · `[P1]` important (in default
+  suite) · `⭐` edge case (in default suite) · **no tag** = only runs on `/e2e-test full` or a
+  scoped `/e2e-test <area>`.
+- Keep it **imperative and observable** — say what to tap and what should appear. If the result
+  isn't visible in the UI, name the DB value/table that confirms it (e.g. `workout_sets.custom_fields`).
+- **New feature?** Add a new `## <Feature> — \`<keyword>\`` section, and add `<keyword>` to the
+  **Args** list near the top so `/e2e-test <keyword>` can scope to it. Bump the schema note if it
+  needs a migration.
+- Prefer cases that seed their own preconditions (add a gym, apply a split, SQL-seed a row) so the
+  suite is repeatable on any DB state.
+
+# Report format
+
+End with a concise report:
+
+- **Environment:** built from `<branch>` @ `<short-sha or "working tree">`, schema v`<N>`, emulator.
+- **Results table:** one row per case run — `AREA · case → PASS/FAIL` (+ one-line note on failures,
+  with the failing screenshot referenced).
+- **DB confirmations:** any values you checked (e.g. `tracking_type`, `custom_fields`, `user_version`).
+- **Not verified:** anything blocked by an emulator limitation (modal typing, etc.) — say so
+  explicitly rather than implying it passed.
+- If you set `debuggable true` or changed the system clock, confirm you reverted both.

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ yarn-error.*
 .omc/
 *.pem
 
+# Claude Code — keep shared skills, ignore machine-local settings
+.claude/settings.local.json
+
 # local env files
 .env*.local
 

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "Vext Dev",
     "slug": "vext",
     "scheme": "vext",
-    "version": "1.11.1",
+    "version": "1.12.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/app/(tabs)/workouts.tsx
+++ b/app/(tabs)/workouts.tsx
@@ -10,7 +10,7 @@ import { useRepeatWorkout, useDeleteWorkout, useDeleteWorkouts, useContinueWorko
 import { useGymGate } from '@frontend/hooks/useGymGate';
 import { useAllGyms } from '@frontend/hooks/useGyms';
 import { useRouter } from 'expo-router';
-import { formatDate, formatDuration, parseUTCTimestamp } from '@shared/utils/formatting';
+import { formatDate, formatDuration, parseUTCTimestamp, formatSetSummary } from '@shared/utils/formatting';
 import { cn } from '@frontend/lib/utils';
 import type { WorkoutSummary, WorkoutGroup, WorkoutExerciseFull } from '@shared/types/workout';
 
@@ -407,11 +407,7 @@ export default function WorkoutsScreen() {
                                         <Text className="text-[10px] font-bold text-foreground-subtle">{set.setNumber}</Text>
                                       </View>
                                       <Text className="text-sm text-foreground-muted">
-                                        {set.weightKg != null && set.reps != null
-                                          ? `${set.weightKg} kg × ${set.reps} reps`
-                                          : set.durationSeconds != null
-                                            ? `${set.durationSeconds}s${set.distanceMeters != null ? ` · ${set.distanceMeters}m` : ''}`
-                                            : '—'}
+                                        {formatSetSummary(set)}
                                       </Text>
                                     </View>
                                   ))}
@@ -445,11 +441,7 @@ export default function WorkoutsScreen() {
                                           const set = ge.sets[roundIndex];
                                           return (
                                             <Text key={ge.id} className="text-xs text-foreground-subtle py-0.5">
-                                              {set && set.weightKg != null && set.reps != null
-                                                ? `${set.weightKg} kg × ${set.reps}`
-                                                : set && set.durationSeconds != null
-                                                  ? `${set.durationSeconds}s${set.distanceMeters != null ? ` · ${set.distanceMeters}m` : ''}`
-                                                  : '—'}
+                                              {set ? formatSetSummary(set) : '—'}
                                             </Text>
                                           );
                                         })}

--- a/app/splits/[id].tsx
+++ b/app/splits/[id].tsx
@@ -43,7 +43,7 @@ function DayTemplate({ seriesId, seriesName }: { seriesId: string; seriesName: s
           <View className="flex-row items-center justify-between">
             <Text className="flex-1 text-sm font-semibold text-foreground">{ex.exerciseName}</Text>
             <Text className="text-xs font-medium text-primary">
-              {formatPrescription(ex.targetSets, ex.targetRepsMin, ex.targetRepsMax, ex.repGoalType)}
+              {formatPrescription(ex.targetSets, ex.targetRepsMin, ex.targetRepsMax, ex.repGoalType, ex.trackingType)}
             </Text>
           </View>
           <Text className="mt-0.5 text-xs text-foreground-subtle">Rest {formatRestShort(ex.restSeconds)}</Text>

--- a/src/backend/database/migrations.ts
+++ b/src/backend/database/migrations.ts
@@ -567,6 +567,16 @@ const migrations: Migration[] = [
       CREATE INDEX idx_food_log_entries_date ON food_log_entries(date);
     `);
   },
+  // v20 → v21: Per-exercise tracking type. An exercise is now logged as one of:
+  // 'weighted' (weight × reps, the default), 'time' (a duration hold in seconds, optionally
+  // AMRAP "max hold"), or 'bodyweight' (a free-text load like "bw"/"green band"/"+5kg" × reps,
+  // stored in the set's existing custom_fields JSON). Existing exercises default to 'weighted'
+  // so there's no behavior change on upgrade.
+  async (db) => {
+    await db.execAsync(`
+      ALTER TABLE exercises ADD COLUMN tracking_type TEXT NOT NULL DEFAULT 'weighted';
+    `);
+  },
 ];
 
 export async function runMigrations(db: SQLite.SQLiteDatabase): Promise<void> {

--- a/src/backend/database/seed.ts
+++ b/src/backend/database/seed.ts
@@ -55,13 +55,14 @@ export async function seedDatabase(db: SQLite.SQLiteDatabase): Promise<void> {
     for (const exercise of SEED_EXERCISES) {
       const id = Crypto.randomUUID();
       await db.runAsync(
-        'INSERT INTO exercises (id, name, category, primary_muscles, equipment, instructions, is_default) VALUES (?, ?, ?, ?, ?, ?, 1)',
+        'INSERT INTO exercises (id, name, category, primary_muscles, equipment, instructions, tracking_type, is_default) VALUES (?, ?, ?, ?, ?, ?, ?, 1)',
         id,
         exercise.name,
         exercise.category,
         JSON.stringify(exercise.primaryMuscles),
         exercise.equipment,
-        exercise.instructions
+        exercise.instructions,
+        exercise.trackingType ?? 'weighted'
       );
     }
   });

--- a/src/backend/database/seedSplit.ts
+++ b/src/backend/database/seedSplit.ts
@@ -109,14 +109,15 @@ async function ensureExercises(db: SQLite.SQLiteDatabase): Promise<Map<string, s
       continue;
     }
     await db.runAsync(
-      `INSERT OR IGNORE INTO exercises (id, name, category, primary_muscles, equipment, instructions, is_default)
-       VALUES (?, ?, ?, ?, ?, ?, 1)`,
+      `INSERT OR IGNORE INTO exercises (id, name, category, primary_muscles, equipment, instructions, tracking_type, is_default)
+       VALUES (?, ?, ?, ?, ?, ?, ?, 1)`,
       Crypto.randomUUID(),
       seed.name,
       seed.category,
       JSON.stringify(seed.primaryMuscles),
       seed.equipment,
-      seed.instructions
+      seed.instructions,
+      seed.trackingType ?? 'weighted'
     );
   }
 

--- a/src/backend/models/exercise.ts
+++ b/src/backend/models/exercise.ts
@@ -4,6 +4,7 @@ import * as Crypto from 'expo-crypto';
 import {
   Exercise,
   ExerciseCategory,
+  ExerciseTrackingType,
   Equipment,
   MuscleGroup,
 } from '@shared/types/exercise';
@@ -16,6 +17,7 @@ interface ExerciseRow {
   equipment: string;
   instructions: string | null;
   rest_seconds: number | null;
+  tracking_type: string;
   is_default: number;
   archived_at: string | null;
   created_at: string;
@@ -38,6 +40,7 @@ function mapRow(row: ExerciseRow): Exercise {
     equipment: row.equipment as Equipment,
     instructions: row.instructions,
     restSeconds: row.rest_seconds,
+    trackingType: (row.tracking_type as ExerciseTrackingType) ?? ExerciseTrackingType.Weighted,
     isDefault: row.is_default === 1,
     archivedAt: row.archived_at,
     createdAt: row.created_at,
@@ -106,19 +109,21 @@ export async function create(
     equipment: Equipment;
     instructions?: string | null;
     restSeconds?: number | null;
+    trackingType?: ExerciseTrackingType;
   }
 ): Promise<Exercise> {
   const id = Crypto.randomUUID();
   await db.runAsync(
-    `INSERT INTO exercises (id, name, category, primary_muscles, equipment, instructions, rest_seconds, is_default, created_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, 0, datetime('now'))`,
+    `INSERT INTO exercises (id, name, category, primary_muscles, equipment, instructions, rest_seconds, tracking_type, is_default, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, datetime('now'))`,
     id,
     data.name,
     data.category,
     JSON.stringify(data.primaryMuscles),
     data.equipment,
     data.instructions ?? null,
-    data.restSeconds ?? null
+    data.restSeconds ?? null,
+    data.trackingType ?? ExerciseTrackingType.Weighted
   );
   const exercise = await getById(db, id);
   if (!exercise) throw new Error(`Failed to create exercise with id ${id}`);
@@ -135,6 +140,7 @@ export async function update(
     equipment?: Equipment;
     instructions?: string | null;
     restSeconds?: number | null;
+    trackingType?: ExerciseTrackingType;
   }
 ): Promise<Exercise> {
   const fields: string[] = [];
@@ -146,6 +152,7 @@ export async function update(
   if (data.equipment !== undefined) { fields.push('equipment = ?'); values.push(data.equipment); }
   if (data.instructions !== undefined) { fields.push('instructions = ?'); values.push(data.instructions); }
   if (data.restSeconds !== undefined) { fields.push('rest_seconds = ?'); values.push(data.restSeconds); }
+  if (data.trackingType !== undefined) { fields.push('tracking_type = ?'); values.push(data.trackingType); }
 
   if (fields.length === 0) {
     const exercise = await getById(db, id);

--- a/src/backend/models/workoutExercise.ts
+++ b/src/backend/models/workoutExercise.ts
@@ -5,6 +5,7 @@ import {
   WorkoutExercise,
   WorkoutExerciseFull,
 } from '@shared/types/workout';
+import { ExerciseTrackingType } from '@shared/types/exercise';
 
 interface WorkoutExerciseRow {
   id: string;
@@ -25,6 +26,7 @@ interface WorkoutExerciseRow {
 interface WorkoutExerciseFullRow extends WorkoutExerciseRow {
   exercise_name: string;
   exercise_category: string;
+  exercise_tracking_type: string;
   note_text: string | null;
 }
 
@@ -51,6 +53,7 @@ function mapFullRow(row: WorkoutExerciseFullRow): WorkoutExerciseFull {
     ...mapRow(row),
     exerciseName: row.exercise_name,
     exerciseCategory: row.exercise_category,
+    trackingType: (row.exercise_tracking_type as ExerciseTrackingType) ?? ExerciseTrackingType.Weighted,
     note: row.note_text ?? null,
     sets: [],
   };
@@ -109,6 +112,7 @@ export async function getByWorkout(
        we.*,
        e.name  AS exercise_name,
        e.category AS exercise_category,
+       e.tracking_type AS exercise_tracking_type,
        eon.notes AS note_text
      FROM workout_exercises we
      JOIN exercises e ON e.id = we.exercise_id
@@ -230,6 +234,7 @@ export async function getBySuperset(
        we.*,
        e.name AS exercise_name,
        e.category AS exercise_category,
+       e.tracking_type AS exercise_tracking_type,
        eon.notes AS note_text
      FROM workout_exercises we
      JOIN exercises e ON e.id = we.exercise_id

--- a/src/backend/models/workoutSet.ts
+++ b/src/backend/models/workoutSet.ts
@@ -188,7 +188,7 @@ export async function getLatestSetsForExercise(
        AND EXISTS (
          SELECT 1 FROM workout_sets ws
          WHERE ws.workout_exercise_id = we.id
-           AND (ws.weight_kg IS NOT NULL OR ws.duration_seconds IS NOT NULL OR ws.distance_meters IS NOT NULL)
+           AND (ws.weight_kg IS NOT NULL OR ws.reps IS NOT NULL OR ws.duration_seconds IS NOT NULL OR ws.distance_meters IS NOT NULL)
        )
      ORDER BY w.completed_at DESC
      LIMIT 1`,

--- a/src/backend/services/exerciseService.ts
+++ b/src/backend/services/exerciseService.ts
@@ -1,7 +1,7 @@
 /** Exercise service - business logic for creating, updating, and archiving exercises. */
 import type * as SQLite from 'expo-sqlite';
 import * as exerciseModel from '@backend/models/exercise';
-import type { Exercise, ExerciseCategory, Equipment, MuscleGroup } from '@shared/types/exercise';
+import type { Exercise, ExerciseCategory, ExerciseTrackingType, Equipment, MuscleGroup } from '@shared/types/exercise';
 
 export async function updateDefaultRestSeconds(
   db: SQLite.SQLiteDatabase,
@@ -20,6 +20,7 @@ export async function createExercise(
     equipment: Equipment;
     instructions?: string | null;
     restSeconds?: number | null;
+    trackingType?: ExerciseTrackingType;
   }
 ): Promise<Exercise> {
   return exerciseModel.create(db, data);
@@ -35,6 +36,7 @@ export async function updateExercise(
     equipment?: Equipment;
     instructions?: string | null;
     restSeconds?: number | null;
+    trackingType?: ExerciseTrackingType;
   }
 ): Promise<Exercise> {
   return exerciseModel.update(db, id, data);

--- a/src/backend/services/splitService.ts
+++ b/src/backend/services/splitService.ts
@@ -5,6 +5,7 @@ import * as splitModel from '@backend/models/split';
 import * as splitDayModel from '@backend/models/splitDay';
 import * as scheduledWorkoutModel from '@backend/models/scheduledWorkout';
 import type { Split, SplitDayType, SplitFull, SeriesTemplate, SeriesTemplateExercise } from '@shared/types/split';
+import { ExerciseTrackingType } from '@shared/types/exercise';
 
 export async function getSplits(db: SQLite.SQLiteDatabase): Promise<Split[]> {
   return splitModel.getAll(db);
@@ -142,6 +143,7 @@ interface TemplateSlotRow {
   target_reps_min: number | null;
   target_reps_max: number | null;
   rep_goal_type: string;
+  tracking_type: string;
   notes: string | null;
 }
 
@@ -162,7 +164,7 @@ export async function getSeriesTemplate(
   seriesName: string
 ): Promise<SeriesTemplate> {
   const slots = await db.getAllAsync<TemplateSlotRow>(
-    `SELECT s.id AS slot_id, eo.exercise_id, e.name AS exercise_name,
+    `SELECT s.id AS slot_id, eo.exercise_id, e.name AS exercise_name, e.tracking_type,
             eo.rest_seconds, eo.target_sets, eo.target_reps_min, eo.target_reps_max,
             eo.rep_goal_type, n.notes AS notes
      FROM exercise_slots s
@@ -199,6 +201,7 @@ export async function getSeriesTemplate(
     targetRepsMin: s.target_reps_min,
     targetRepsMax: s.target_reps_max,
     repGoalType: (s.rep_goal_type as 'range' | 'amrap') ?? 'range',
+    trackingType: (s.tracking_type as ExerciseTrackingType) ?? ExerciseTrackingType.Weighted,
     note: s.notes,
     alternatives: altsBySlot.get(s.slot_id) ?? [],
   }));

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -2,7 +2,7 @@
 export const APP_CONFIG = {
   database: {
     name: 'vext.db',
-    schemaVersion: 20,
+    schemaVersion: 21,
   },
   defaults: {
     restSeconds: {

--- a/src/frontend/components/overlay/ExerciseForm.tsx
+++ b/src/frontend/components/overlay/ExerciseForm.tsx
@@ -1,15 +1,23 @@
 /** ExerciseForm - full-screen modal for creating and editing exercises. */
 import React, { useState, useEffect } from 'react';
 import { Modal, View, Text, TextInput, Pressable, ScrollView, Alert } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { cn } from '@frontend/lib/utils';
 import { MUSCLE_GROUP_LABELS, ALL_MUSCLE_GROUPS } from '@shared/constants/muscleGroups';
 import { EQUIPMENT_LABELS, ALL_EQUIPMENT } from '@shared/constants/equipment';
+import { ExerciseTrackingType, TRACKING_TYPE_LABELS } from '@shared/types/exercise';
 import type { Exercise, ExerciseCategory, MuscleGroup, Equipment } from '@shared/types/exercise';
 
 const CATEGORIES: { label: string; value: ExerciseCategory }[] = [
   { label: 'Strength', value: 'strength' as ExerciseCategory },
   { label: 'Cardio', value: 'cardio' as ExerciseCategory },
   { label: 'Flexibility', value: 'flexibility' as ExerciseCategory },
+];
+
+const TRACKING_TYPES: { label: string; value: ExerciseTrackingType; hint: string }[] = [
+  { label: TRACKING_TYPE_LABELS[ExerciseTrackingType.Weighted], value: ExerciseTrackingType.Weighted, hint: 'kg × reps' },
+  { label: TRACKING_TYPE_LABELS[ExerciseTrackingType.Bodyweight], value: ExerciseTrackingType.Bodyweight, hint: 'free load (bw / band / +5kg) × reps' },
+  { label: TRACKING_TYPE_LABELS[ExerciseTrackingType.Time], value: ExerciseTrackingType.Time, hint: 'a timed hold in seconds' },
 ];
 
 type ExerciseFormData = {
@@ -19,6 +27,7 @@ type ExerciseFormData = {
   equipment: Equipment;
   instructions: string | null;
   restSeconds: number | null;
+  trackingType: ExerciseTrackingType;
 };
 
 type ExerciseFormProps = {
@@ -35,6 +44,7 @@ export function ExerciseForm({ visible, onClose, onSave, exercise }: ExerciseFor
   const [equipment, setEquipment] = useState<Equipment>('bodyweight' as Equipment);
   const [instructions, setInstructions] = useState('');
   const [restSeconds, setRestSeconds] = useState<number | null>(null);
+  const [trackingType, setTrackingType] = useState<ExerciseTrackingType>(ExerciseTrackingType.Weighted);
 
   const isEditing = !!exercise;
 
@@ -46,6 +56,7 @@ export function ExerciseForm({ visible, onClose, onSave, exercise }: ExerciseFor
       setEquipment(exercise.equipment);
       setInstructions(exercise.instructions ?? '');
       setRestSeconds(exercise.restSeconds);
+      setTrackingType(exercise.trackingType);
     } else if (visible) {
       setName('');
       setCategory('strength' as ExerciseCategory);
@@ -53,6 +64,7 @@ export function ExerciseForm({ visible, onClose, onSave, exercise }: ExerciseFor
       setEquipment('bodyweight' as Equipment);
       setInstructions('');
       setRestSeconds(null);
+      setTrackingType(ExerciseTrackingType.Weighted);
     }
   }, [visible, exercise]);
 
@@ -75,6 +87,7 @@ export function ExerciseForm({ visible, onClose, onSave, exercise }: ExerciseFor
       equipment,
       instructions: instructions.trim() || null,
       restSeconds,
+      trackingType,
     });
     onClose();
   };
@@ -129,6 +142,32 @@ export function ExerciseForm({ visible, onClose, onSave, exercise }: ExerciseFor
                 </Text>
               </Pressable>
             ))}
+          </View>
+
+          {/* Tracking type */}
+          <Text className="mt-5 text-sm font-medium text-foreground">Tracking</Text>
+          <View className="mt-2 gap-2">
+            {TRACKING_TYPES.map((t) => {
+              const isSelected = trackingType === t.value;
+              return (
+                <Pressable
+                  key={t.value}
+                  onPress={() => setTrackingType(t.value)}
+                  className={cn(
+                    'flex-row items-center justify-between rounded-xl px-4 py-3',
+                    isSelected ? 'bg-primary/20 border border-primary' : 'bg-background-50 border border-transparent'
+                  )}
+                >
+                  <View className="flex-1 pr-2">
+                    <Text className={cn('text-sm font-medium', isSelected ? 'text-primary' : 'text-foreground')}>
+                      {t.label}
+                    </Text>
+                    <Text className="text-xs text-foreground-subtle">{t.hint}</Text>
+                  </View>
+                  {isSelected && <Ionicons name="checkmark-circle" size={20} color="rgb(52, 211, 153)" />}
+                </Pressable>
+              );
+            })}
           </View>
 
           {/* Primary Muscles */}

--- a/src/frontend/components/workout/ExerciseCard.tsx
+++ b/src/frontend/components/workout/ExerciseCard.tsx
@@ -3,9 +3,11 @@ import React, { useState, useEffect } from 'react';
 import { View, Text, TextInput, Pressable } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { SetRow } from './SetRow';
+import { getSetInputMode, isSetComplete } from './setInputMode';
 import { AlternativesModal } from './AlternativesModal';
 import { ConfirmDialog } from '@frontend/components/overlay/ConfirmDialog';
 import type { WorkoutExerciseFull, WorkoutSet } from '@shared/types/workout';
+import type { WorkoutSetInput } from '@backend/models/workoutSet';
 
 function parseRepRange(input: string): { min: number | null; max: number | null } {
   const trimmed = input.trim();
@@ -37,7 +39,7 @@ type ExerciseCardProps = {
   onMoveUp?: () => void;
   onMoveDown?: () => void;
   onAddSet: () => void;
-  onSaveSet: (setId: string, data: { weightKg?: number; reps?: number; durationSeconds?: number; distanceMeters?: number }) => void;
+  onSaveSet: (setId: string, data: WorkoutSetInput) => void;
   onRemoveSet: (setId: string) => void;
   onRemoveExercise: () => void;
   onUpdateRestSeconds: (seconds: number) => void;
@@ -65,6 +67,7 @@ export const ExerciseCard = React.memo(function ExerciseCard({
   onMakeSuperset,
   onSwitchToAlternative,
 }: ExerciseCardProps) {
+  const mode = getSetInputMode(isStrength, exercise.trackingType);
   const [showRemoveConfirm, setShowRemoveConfirm] = useState(false);
   const [editingRest, setEditingRest] = useState(false);
   const [editingRepGoal, setEditingRepGoal] = useState(false);
@@ -92,14 +95,12 @@ export const ExerciseCard = React.memo(function ExerciseCard({
   // Auto-collapse once when all sets are done; never re-triggers after manual expand
   useEffect(() => {
     if (hasAutoCollapsed || exercise.sets.length === 0) return;
-    const allDone = isStrength
-      ? exercise.sets.every((s) => s.weightKg != null && s.reps != null)
-      : exercise.sets.every((s) => s.durationSeconds != null);
+    const allDone = exercise.sets.every((s) => isSetComplete(mode, s));
     if (allDone) {
       setIsCollapsed(true);
       setHasAutoCollapsed(true);
     }
-  }, [exercise.sets, isStrength, hasAutoCollapsed]);
+  }, [exercise.sets, mode, hasAutoCollapsed]);
 
   const handleUpdateRest = (newVal: number) => {
     setLocalRestSeconds(newVal);
@@ -158,17 +159,19 @@ export const ExerciseCard = React.memo(function ExerciseCard({
                     </Text>
                   </Pressable>
 
-                  <Pressable
-                    onPress={() => setEditingRepGoal(!editingRepGoal)}
-                    className="flex-row items-center rounded-full bg-background-100 px-3 py-1"
-                  >
-                    <Ionicons name="fitness-outline" size={14} color="rgb(163, 163, 163)" />
-                    <Text className="ml-1 text-xs text-foreground-muted">
-                      {exercise.targetRepsMin != null && exercise.targetRepsMax != null
-                        ? `Goal: ${formatRepRange(exercise.targetRepsMin, exercise.targetRepsMax)} reps`
-                        : 'Rep goal'}
-                    </Text>
-                  </Pressable>
+                  {mode !== 'time' && (
+                    <Pressable
+                      onPress={() => setEditingRepGoal(!editingRepGoal)}
+                      className="flex-row items-center rounded-full bg-background-100 px-3 py-1"
+                    >
+                      <Ionicons name="fitness-outline" size={14} color="rgb(163, 163, 163)" />
+                      <Text className="ml-1 text-xs text-foreground-muted">
+                        {exercise.targetRepsMin != null && exercise.targetRepsMax != null
+                          ? `Goal: ${formatRepRange(exercise.targetRepsMin, exercise.targetRepsMax)} reps`
+                          : 'Rep goal'}
+                      </Text>
+                    </Pressable>
+                  )}
 
                   {onSaveNote && (
                     <Pressable
@@ -268,13 +271,24 @@ export const ExerciseCard = React.memo(function ExerciseCard({
                 {/* Header row */}
                 <View className="flex-row items-center py-1 gap-2 mb-1">
                   <View className="w-8" />
-                  {isStrength ? (
+                  {mode === 'weighted' && (
                     <>
                       <Text className="flex-1 text-center text-xs text-foreground-subtle">Weight</Text>
                       <Text className="text-xs text-foreground-subtle" />
                       <Text className="flex-1 text-center text-xs text-foreground-subtle">Reps</Text>
                     </>
-                  ) : (
+                  )}
+                  {mode === 'bodyweight' && (
+                    <>
+                      <Text className="flex-1 text-center text-xs text-foreground-subtle">Load</Text>
+                      <Text className="text-xs text-foreground-subtle" />
+                      <Text className="flex-1 text-center text-xs text-foreground-subtle">Reps</Text>
+                    </>
+                  )}
+                  {mode === 'time' && (
+                    <Text className="flex-1 text-center text-xs text-foreground-subtle">Duration (s)</Text>
+                  )}
+                  {mode === 'cardio' && (
                     <>
                       <Text className="flex-1 text-center text-xs text-foreground-subtle">Duration</Text>
                       <Text className="flex-1 text-center text-xs text-foreground-subtle">Distance</Text>
@@ -291,7 +305,7 @@ export const ExerciseCard = React.memo(function ExerciseCard({
                     set={set}
                     previousSet={previousSets?.[index]}
                     setNumber={set.setNumber}
-                    isStrength={isStrength}
+                    mode={mode}
                     targetRepsMin={exercise.targetRepsMin}
                     targetRepsMax={exercise.targetRepsMax}
                     restSeconds={exercise.restSeconds}

--- a/src/frontend/components/workout/SetRow.tsx
+++ b/src/frontend/components/workout/SetRow.tsx
@@ -1,9 +1,11 @@
-/** SetRow - editable row for a single set with weight, reps, and color-coded rep feedback. */
-import React, { useState, useEffect } from 'react';
+/** SetRow - editable row for a single set; which inputs show depend on the exercise's tracking mode. */
+import React, { useState, useEffect, useRef } from 'react';
 import { View, Text, TextInput, Pressable } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { cn } from '@frontend/lib/utils';
 import type { WorkoutSet } from '@shared/types/workout';
+import type { WorkoutSetInput } from '@backend/models/workoutSet';
+import { SetInputMode, getSetLoad } from './setInputMode';
 
 function getRepsColor(reps: number | null, min: number | null, max: number | null): string {
   if (reps == null || min == null || max == null) return 'text-foreground';
@@ -16,22 +18,26 @@ type SetRowProps = {
   set?: WorkoutSet;
   previousSet?: WorkoutSet;
   setNumber: number;
-  isStrength: boolean;
+  mode: SetInputMode;
   targetRepsMin?: number | null;
   targetRepsMax?: number | null;
   restSeconds?: number;
   hideSetNumber?: boolean;
-  onSave: (data: { weightKg?: number; reps?: number; durationSeconds?: number; distanceMeters?: number }) => void;
+  onSave: (data: WorkoutSetInput) => void;
   onStartRest?: () => void;
   onRemove?: () => void;
 };
 
-export function SetRow({ set, previousSet, setNumber, isStrength, targetRepsMin, targetRepsMax, restSeconds, hideSetNumber, onSave, onStartRest, onRemove }: SetRowProps) {
+export function SetRow({ set, previousSet, setNumber, mode, targetRepsMin, targetRepsMax, restSeconds, hideSetNumber, onSave, onStartRest, onRemove }: SetRowProps) {
   const [weight, setWeight] = useState(set?.weightKg?.toString() ?? '');
   const [reps, setReps] = useState(set?.reps?.toString() ?? '');
   const [duration, setDuration] = useState(set?.durationSeconds?.toString() ?? '');
   const [distance, setDistance] = useState(set?.distanceMeters?.toString() ?? '');
+  const [load, setLoad] = useState(set ? getSetLoad(set) ?? '' : '');
   const [saved, setSaved] = useState(!!set);
+  const [running, setRunning] = useState(false);
+  const startRef = useRef<number | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
     if (set) {
@@ -39,29 +45,65 @@ export function SetRow({ set, previousSet, setNumber, isStrength, targetRepsMin,
       setReps(set.reps?.toString() ?? '');
       setDuration(set.durationSeconds?.toString() ?? '');
       setDistance(set.distanceMeters?.toString() ?? '');
+      setLoad(getSetLoad(set) ?? '');
       setSaved(true);
     }
   }, [set]);
 
+  // Clean up the stopwatch interval on unmount.
+  useEffect(() => () => { if (intervalRef.current) clearInterval(intervalRef.current); }, []);
+
   const handleSave = () => {
-    if (isStrength) {
+    if (mode === 'weighted') {
       const w = weight ? parseFloat(weight) : undefined;
       const r = reps ? parseInt(reps, 10) : undefined;
-      if (w !== undefined || r !== undefined) {
-        onSave({ weightKg: w, reps: r });
-        setSaved(true);
-      }
+      if (w !== undefined || r !== undefined) { onSave({ weightKg: w, reps: r }); setSaved(true); }
+    } else if (mode === 'bodyweight') {
+      const r = reps ? parseInt(reps, 10) : undefined;
+      const l = load.trim();
+      if (r !== undefined || l) { onSave({ reps: r, customFields: l ? { load: l } : null }); setSaved(true); }
+    } else if (mode === 'time') {
+      const d = duration ? parseInt(duration, 10) : undefined;
+      if (d !== undefined) { onSave({ durationSeconds: d }); setSaved(true); }
     } else {
       const d = duration ? parseInt(duration, 10) : undefined;
       const dist = distance ? parseFloat(distance) : undefined;
-      if (d !== undefined || dist !== undefined) {
-        onSave({ durationSeconds: d, distanceMeters: dist });
-        setSaved(true);
-      }
+      if (d !== undefined || dist !== undefined) { onSave({ durationSeconds: d, distanceMeters: dist }); setSaved(true); }
+    }
+  };
+
+  const toggleStopwatch = () => {
+    if (running) {
+      const secs = startRef.current != null
+        ? Math.max(1, Math.round((Date.now() - startRef.current) / 1000))
+        : (duration ? parseInt(duration, 10) : 0);
+      if (intervalRef.current) { clearInterval(intervalRef.current); intervalRef.current = null; }
+      setRunning(false);
+      setDuration(String(secs));
+      onSave({ durationSeconds: secs });
+      setSaved(true);
+    } else {
+      startRef.current = Date.now();
+      setDuration('0');
+      setSaved(false);
+      setRunning(true);
+      intervalRef.current = setInterval(() => {
+        if (startRef.current != null) {
+          setDuration(String(Math.round((Date.now() - startRef.current) / 1000)));
+        }
+      }, 250);
     }
   };
 
   const showRestButton = (restSeconds ?? 0) > 0 && !!onStartRest;
+
+  const lastText = (() => {
+    if (!previousSet) return null;
+    if (mode === 'weighted') return `Last: ${previousSet.weightKg ?? 0}kg x ${previousSet.reps ?? 0}`;
+    if (mode === 'bodyweight') return `Last: ${getSetLoad(previousSet) ?? 'bw'} x ${previousSet.reps ?? 0}`;
+    if (mode === 'time') return `Last: ${previousSet.durationSeconds ?? 0}s`;
+    return `Last: ${previousSet.durationSeconds ?? 0}s${previousSet.distanceMeters != null ? ` · ${previousSet.distanceMeters}m` : ''}`;
+  })();
 
   return (
     <View>
@@ -72,7 +114,7 @@ export function SetRow({ set, previousSet, setNumber, isStrength, targetRepsMin,
           </View>
         )}
 
-        {isStrength ? (
+        {mode === 'weighted' && (
           <>
             <TextInput
               className="h-10 flex-1 rounded-lg bg-background-100 px-3 text-center text-sm text-foreground"
@@ -87,9 +129,7 @@ export function SetRow({ set, previousSet, setNumber, isStrength, targetRepsMin,
             <TextInput
               className={cn(
                 'h-10 flex-1 rounded-lg bg-background-100 px-3 text-center text-sm',
-                saved && reps
-                  ? getRepsColor(parseInt(reps, 10), targetRepsMin ?? null, targetRepsMax ?? null)
-                  : 'text-foreground'
+                saved && reps ? getRepsColor(parseInt(reps, 10), targetRepsMin ?? null, targetRepsMax ?? null) : 'text-foreground'
               )}
               placeholder="reps"
               placeholderTextColor="rgb(115, 115, 115)"
@@ -99,7 +139,57 @@ export function SetRow({ set, previousSet, setNumber, isStrength, targetRepsMin,
               onBlur={handleSave}
             />
           </>
-        ) : (
+        )}
+
+        {mode === 'bodyweight' && (
+          <>
+            <TextInput
+              className="h-10 flex-1 rounded-lg bg-background-100 px-3 text-center text-sm text-foreground"
+              placeholder="load"
+              placeholderTextColor="rgb(115, 115, 115)"
+              autoCapitalize="none"
+              value={load}
+              onChangeText={(v) => { setLoad(v); setSaved(false); }}
+              onBlur={handleSave}
+            />
+            <Text className="text-foreground-subtle text-xs">x</Text>
+            <TextInput
+              className={cn(
+                'h-10 flex-1 rounded-lg bg-background-100 px-3 text-center text-sm',
+                saved && reps ? getRepsColor(parseInt(reps, 10), targetRepsMin ?? null, targetRepsMax ?? null) : 'text-foreground'
+              )}
+              placeholder="reps"
+              placeholderTextColor="rgb(115, 115, 115)"
+              keyboardType="number-pad"
+              value={reps}
+              onChangeText={(v) => { setReps(v); setSaved(false); }}
+              onBlur={handleSave}
+            />
+          </>
+        )}
+
+        {mode === 'time' && (
+          <>
+            <TextInput
+              className="h-10 flex-1 rounded-lg bg-background-100 px-3 text-center text-sm text-foreground"
+              placeholder="sec"
+              placeholderTextColor="rgb(115, 115, 115)"
+              keyboardType="number-pad"
+              value={duration}
+              editable={!running}
+              onChangeText={(v) => { setDuration(v); setSaved(false); }}
+              onBlur={handleSave}
+            />
+            <Pressable
+              onPress={toggleStopwatch}
+              className={cn('w-10 h-10 items-center justify-center rounded-lg', running ? 'bg-destructive/20' : 'bg-background-100')}
+            >
+              <Ionicons name={running ? 'stop' : 'play'} size={16} color={running ? 'rgb(239, 68, 68)' : 'rgb(52, 211, 153)'} />
+            </Pressable>
+          </>
+        )}
+
+        {mode === 'cardio' && (
           <>
             <TextInput
               className="h-10 flex-1 rounded-lg bg-background-100 px-3 text-center text-sm text-foreground"
@@ -137,13 +227,9 @@ export function SetRow({ set, previousSet, setNumber, isStrength, targetRepsMin,
         )}
       </View>
 
-      {previousSet && (
+      {lastText && (
         <View className="ml-10 -mt-1 mb-1">
-          <Text className="text-xs text-foreground-subtle">
-            {isStrength
-              ? `Last: ${previousSet.weightKg ?? 0}kg x ${previousSet.reps ?? 0}`
-              : `Last: ${previousSet.durationSeconds ?? 0}s${previousSet.distanceMeters != null ? ` · ${previousSet.distanceMeters}m` : ''}`}
-          </Text>
+          <Text className="text-xs text-foreground-subtle">{lastText}</Text>
         </View>
       )}
     </View>

--- a/src/frontend/components/workout/SupersetCard.tsx
+++ b/src/frontend/components/workout/SupersetCard.tsx
@@ -3,9 +3,11 @@ import React, { useState, useEffect } from 'react';
 import { View, Text, Pressable, Modal, TextInput } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { SetRow } from './SetRow';
+import { getSetInputMode, isSetComplete, getSetLoad } from './setInputMode';
 import { ConfirmDialog } from '@frontend/components/overlay/ConfirmDialog';
 import { SupersetAlternativesModal } from './SupersetAlternativesModal';
 import type { WorkoutExerciseFull, WorkoutSet, SupersetGroup } from '@shared/types/workout';
+import type { WorkoutSetInput } from '@backend/models/workoutSet';
 
 function parseRepRange(input: string): { min: number | null; max: number | null } {
   const trimmed = input.trim();
@@ -30,14 +32,14 @@ type SupersetCardProps = {
   onMoveUp?: () => void;
   onMoveDown?: () => void;
   onAddRound: () => void;
-  onSaveSet: (setId: string, data: { weightKg?: number; reps?: number; durationSeconds?: number; distanceMeters?: number }) => void;
+  onSaveSet: (setId: string, data: WorkoutSetInput) => void;
   onRemoveSet: (setId: string) => void;
   onRemoveExercise: (workoutExerciseId: string) => void;
   onAddExercise: () => void;
   onDisband: () => void;
   onUpdateRestSeconds: (seconds: number) => void;
   onUpdateTargetReps: (workoutExerciseId: string, min: number | null, max: number | null) => void;
-  onLogSet: (workoutExerciseId: string, data: { weightKg?: number; reps?: number; durationSeconds?: number; distanceMeters?: number }) => void;
+  onLogSet: (workoutExerciseId: string, data: WorkoutSetInput) => void;
   onStartRest: () => void;
   seriesId?: string | null;
   onSwitchToAlternative?: (workoutExerciseId: string, newExerciseId: string) => void;
@@ -100,12 +102,10 @@ export const SupersetCard = React.memo(function SupersetCard({
   // Auto-collapse once when all rounds are fully filled in
   useEffect(() => {
     if (hasAutoCollapsed || numRounds === 0) return;
-    const allDone = exercises.every((ex) =>
-      ex.sets.length === numRounds &&
-      ex.sets.every((s) =>
-        isStrength ? s.weightKg != null && s.reps != null : s.durationSeconds != null
-      )
-    );
+    const allDone = exercises.every((ex) => {
+      const exMode = getSetInputMode(isStrength, ex.trackingType);
+      return ex.sets.length === numRounds && ex.sets.every((s) => isSetComplete(exMode, s));
+    });
     if (allDone) {
       setIsCollapsed(true);
       setHasAutoCollapsed(true);
@@ -222,18 +222,20 @@ export const SupersetCard = React.memo(function SupersetCard({
           {exercises.map((ex) => {
             const set = ex.sets[roundIndex];
             const firstPreviousSet = previousSetsMap.get(ex.exerciseId)?.[0];
+            const exMode = getSetInputMode(isStrength, ex.trackingType);
+            const lastText = firstPreviousSet
+              ? exMode === 'weighted'
+                ? ` - last: ${firstPreviousSet.weightKg ?? 0}kg × ${firstPreviousSet.reps ?? 0}`
+                : exMode === 'bodyweight'
+                  ? ` - last: ${getSetLoad(firstPreviousSet) ?? 'bw'} × ${firstPreviousSet.reps ?? 0}`
+                  : ` - last: ${firstPreviousSet.durationSeconds ?? 0}s${firstPreviousSet.distanceMeters != null ? ` · ${firstPreviousSet.distanceMeters}m` : ''}`
+              : null;
 
             return (
               <View key={ex.id}>
                 <Text className="text-xs font-medium text-foreground-muted mb-0.5">
                   {ex.exerciseName}
-                  {firstPreviousSet ? (
-                    <Text className="text-foreground-subtle">
-                      {isStrength
-                        ? ` - last: ${firstPreviousSet.weightKg ?? 0}kg × ${firstPreviousSet.reps ?? 0}`
-                        : ` - last: ${firstPreviousSet.durationSeconds ?? 0}s${firstPreviousSet.distanceMeters != null ? ` · ${firstPreviousSet.distanceMeters}m` : ''}`}
-                    </Text>
-                  ) : null}
+                  {lastText ? <Text className="text-foreground-subtle">{lastText}</Text> : null}
                 </Text>
                 {ex.note ? (
                   <Text className="text-xs italic text-foreground-subtle mb-0.5">{ex.note}</Text>
@@ -243,7 +245,7 @@ export const SupersetCard = React.memo(function SupersetCard({
                   <SetRow
                     set={set}
                     setNumber={set.setNumber}
-                    isStrength={isStrength}
+                    mode={exMode}
                     targetRepsMin={ex.targetRepsMin}
                     targetRepsMax={ex.targetRepsMax}
                     restSeconds={0}
@@ -253,7 +255,7 @@ export const SupersetCard = React.memo(function SupersetCard({
                 ) : (
                   <SetRow
                     setNumber={roundIndex + 1}
-                    isStrength={isStrength}
+                    mode={exMode}
                     targetRepsMin={ex.targetRepsMin}
                     targetRepsMax={ex.targetRepsMax}
                     restSeconds={0}

--- a/src/frontend/components/workout/setInputMode.ts
+++ b/src/frontend/components/workout/setInputMode.ts
@@ -1,0 +1,40 @@
+/**
+ * setInputMode - resolves how a set's inputs are rendered/logged, combining the workout type
+ * (Strength vs Cardio) with the exercise's per-exercise tracking type. Cardio workouts keep the
+ * duration+distance inputs regardless of tracking type; within a strength workout the exercise's
+ * tracking type decides.
+ */
+import { ExerciseTrackingType } from '@shared/types/exercise';
+
+export type SetInputMode = 'weighted' | 'time' | 'bodyweight' | 'cardio';
+
+export function getSetInputMode(isStrength: boolean, trackingType: ExerciseTrackingType): SetInputMode {
+  if (!isStrength) return 'cardio';
+  switch (trackingType) {
+    case ExerciseTrackingType.Time:
+      return 'time';
+    case ExerciseTrackingType.Bodyweight:
+      return 'bodyweight';
+    default:
+      return 'weighted';
+  }
+}
+
+/** A set counts as "done" (for auto-collapse) once its mode's primary field(s) are filled. */
+export function isSetComplete(mode: SetInputMode, set: { weightKg: number | null; reps: number | null; durationSeconds: number | null; customFields: Record<string, unknown> | null }): boolean {
+  switch (mode) {
+    case 'weighted':
+      return set.weightKg != null && set.reps != null;
+    case 'bodyweight':
+      return set.reps != null;
+    case 'time':
+    case 'cardio':
+      return set.durationSeconds != null;
+  }
+}
+
+/** The free-text load a bodyweight set was logged with (e.g. "bw", "green band", "+5kg"). */
+export function getSetLoad(set: { customFields: Record<string, unknown> | null }): string | null {
+  const load = set.customFields?.load;
+  return typeof load === 'string' && load.length > 0 ? load : null;
+}

--- a/src/frontend/hooks/useExercises.ts
+++ b/src/frontend/hooks/useExercises.ts
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import * as exerciseModel from '@backend/models/exercise';
 import * as exerciseService from '@backend/services/exerciseService';
 import { useDatabase } from '@frontend/hooks/useDatabase';
-import type { ExerciseCategory, Equipment, MuscleGroup } from '@shared/types/exercise';
+import type { ExerciseCategory, ExerciseTrackingType, Equipment, MuscleGroup } from '@shared/types/exercise';
 import { APP_CONFIG } from '@config/app';
 
 export function useExercises(category?: ExerciseCategory) {
@@ -53,6 +53,7 @@ export function useCreateExercise() {
       equipment: Equipment;
       instructions?: string | null;
       restSeconds?: number | null;
+      trackingType?: ExerciseTrackingType;
     }) => exerciseService.createExercise(db, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['exercises'] });
@@ -73,6 +74,7 @@ export function useUpdateExercise() {
         equipment?: Equipment;
         instructions?: string | null;
         restSeconds?: number | null;
+        trackingType?: ExerciseTrackingType;
       };
     }) => exerciseService.updateExercise(db, id, data),
     onSuccess: (_, variables) => {

--- a/src/shared/constants/exercises.ts
+++ b/src/shared/constants/exercises.ts
@@ -1,5 +1,5 @@
 /** Default exercises - seed data for the built-in exercise library. */
-import { ExerciseCategory, MuscleGroup, Equipment, type ExerciseSeed } from '@shared/types/exercise';
+import { ExerciseCategory, ExerciseTrackingType, MuscleGroup, Equipment, type ExerciseSeed } from '@shared/types/exercise';
 
 export const SEED_EXERCISES: ExerciseSeed[] = [
   // === CHEST (Strength) ===
@@ -14,7 +14,7 @@ export const SEED_EXERCISES: ExerciseSeed[] = [
   // === BACK (Strength) ===
   { name: 'Barbell Deadlift', category: ExerciseCategory.Strength, primaryMuscles: [MuscleGroup.Back, MuscleGroup.Hamstrings, MuscleGroup.Glutes], equipment: Equipment.Barbell, instructions: 'Stand with feet hip-width, grip bar, drive through heels, extend hips and knees.' },
   { name: 'Barbell Bent-Over Row', category: ExerciseCategory.Strength, primaryMuscles: [MuscleGroup.Back], equipment: Equipment.Barbell, instructions: 'Hinge at hips, grip bar, pull to lower chest, lower with control.' },
-  { name: 'Pull-Up', category: ExerciseCategory.Strength, primaryMuscles: [MuscleGroup.Back], equipment: Equipment.Bodyweight, instructions: 'Hang from bar, pull chin above bar, lower with control.' },
+  { name: 'Pull-Up', category: ExerciseCategory.Strength, primaryMuscles: [MuscleGroup.Back], equipment: Equipment.Bodyweight, instructions: 'Hang from bar, pull chin above bar, lower with control.', trackingType: ExerciseTrackingType.Bodyweight },
   { name: 'Lat Pulldown', category: ExerciseCategory.Strength, primaryMuscles: [MuscleGroup.Back], equipment: Equipment.Cable, instructions: 'Grip wide bar, pull down to upper chest, squeeze shoulder blades together.' },
   { name: 'Seated Cable Row', category: ExerciseCategory.Strength, primaryMuscles: [MuscleGroup.Back], equipment: Equipment.Cable, instructions: 'Sit upright, pull handle to torso, squeeze shoulder blades, return slowly.' },
   { name: 'Dumbbell Single-Arm Row', category: ExerciseCategory.Strength, primaryMuscles: [MuscleGroup.Back], equipment: Equipment.Dumbbell, instructions: 'One knee on bench, pull dumbbell to hip, lower with control.' },
@@ -59,7 +59,7 @@ export const SEED_EXERCISES: ExerciseSeed[] = [
   { name: 'Seated Calf Raise', category: ExerciseCategory.Strength, primaryMuscles: [MuscleGroup.Calves], equipment: Equipment.Machine, instructions: 'Sit in machine, rise up on toes, lower slowly.' },
 
   // === CORE (Strength) ===
-  { name: 'Plank', category: ExerciseCategory.Strength, primaryMuscles: [MuscleGroup.Core], equipment: Equipment.Bodyweight, instructions: 'Forearms and toes on ground, keep body straight, hold position.' },
+  { name: 'Plank', category: ExerciseCategory.Strength, primaryMuscles: [MuscleGroup.Core], equipment: Equipment.Bodyweight, instructions: 'Forearms and toes on ground, keep body straight, hold position.', trackingType: ExerciseTrackingType.Time },
   { name: 'Hanging Leg Raise', category: ExerciseCategory.Strength, primaryMuscles: [MuscleGroup.Core], equipment: Equipment.Bodyweight, instructions: 'Hang from bar, raise legs to parallel or higher, lower with control.' },
   { name: 'Cable Crunch', category: ExerciseCategory.Strength, primaryMuscles: [MuscleGroup.Core], equipment: Equipment.Cable, instructions: 'Kneel facing cable, hold rope behind head, crunch down contracting abs.' },
   { name: 'Ab Wheel Rollout', category: ExerciseCategory.Strength, primaryMuscles: [MuscleGroup.Core], equipment: Equipment.None, instructions: 'Kneel with ab wheel, roll forward extending body, pull back using core.' },
@@ -78,10 +78,10 @@ export const SEED_EXERCISES: ExerciseSeed[] = [
   { name: 'Cat-Cow Stretch', category: ExerciseCategory.Flexibility, primaryMuscles: [MuscleGroup.Back, MuscleGroup.Core], equipment: Equipment.None, instructions: 'On hands and knees, alternate between arching back (cow) and rounding back (cat).' },
 
   // === ADDITIONS FOR DEFAULT SPLIT (Revival 4-Day Upper/Lower) ===
-  { name: 'Chin-Up', category: ExerciseCategory.Strength, primaryMuscles: [MuscleGroup.Back, MuscleGroup.Biceps], equipment: Equipment.Bodyweight, instructions: 'Hang with palms facing you, pull chin above the bar, lower with control.' },
+  { name: 'Chin-Up', category: ExerciseCategory.Strength, primaryMuscles: [MuscleGroup.Back, MuscleGroup.Biceps], equipment: Equipment.Bodyweight, instructions: 'Hang with palms facing you, pull chin above the bar, lower with control.', trackingType: ExerciseTrackingType.Bodyweight },
   { name: 'Incline Dumbbell Press', category: ExerciseCategory.Strength, primaryMuscles: [MuscleGroup.Chest], equipment: Equipment.Dumbbell, instructions: 'Set bench to 30-45 degrees. Lower dumbbells to upper chest, press up.' },
   { name: 'Pec Deck', category: ExerciseCategory.Strength, primaryMuscles: [MuscleGroup.Chest], equipment: Equipment.Machine, instructions: 'Sit with handles at mid-chest height, bring arms together in front, return slowly.' },
-  { name: 'Side Plank', category: ExerciseCategory.Strength, primaryMuscles: [MuscleGroup.Core], equipment: Equipment.Bodyweight, instructions: 'On one forearm, feet stacked, hold body in a straight line. Can be static or dynamic (hip up and down).' },
+  { name: 'Side Plank', category: ExerciseCategory.Strength, primaryMuscles: [MuscleGroup.Core], equipment: Equipment.Bodyweight, instructions: 'On one forearm, feet stacked, hold body in a straight line. Can be static or dynamic (hip up and down).', trackingType: ExerciseTrackingType.Time },
   { name: 'Inverted Row', category: ExerciseCategory.Strength, primaryMuscles: [MuscleGroup.Back], equipment: Equipment.Bodyweight, instructions: 'Hang under a bar (rack, Smith, or TRX), body straight, pull chest to bar, lower with control.' },
   { name: 'Preacher Curl', category: ExerciseCategory.Strength, primaryMuscles: [MuscleGroup.Biceps], equipment: Equipment.Machine, instructions: 'Arms over the preacher pad, curl up, extend fully without using momentum.' },
   { name: 'Cable Lateral Raise', category: ExerciseCategory.Strength, primaryMuscles: [MuscleGroup.SideDelt], equipment: Equipment.Cable, instructions: 'Stand side-on to a low cable, raise the handle out to shoulder height, lower slowly.' },

--- a/src/shared/types/exercise.ts
+++ b/src/shared/types/exercise.ts
@@ -32,6 +32,24 @@ export enum ExerciseCategory {
   Flexibility = 'flexibility',
 }
 
+/**
+ * How an exercise's sets are measured, independent of the workout type:
+ * - `weighted` — weight (kg) × reps. Default; unchanged behavior.
+ * - `time` — a single duration-in-seconds field (a hold), optionally AMRAP ("max hold").
+ * - `bodyweight` — a free-text load ("bw" / "green band" / "+5kg") × reps, stored on the set.
+ */
+export enum ExerciseTrackingType {
+  Weighted = 'weighted',
+  Time = 'time',
+  Bodyweight = 'bodyweight',
+}
+
+export const TRACKING_TYPE_LABELS: Record<ExerciseTrackingType, string> = {
+  [ExerciseTrackingType.Weighted]: 'Weight × reps',
+  [ExerciseTrackingType.Time]: 'Time',
+  [ExerciseTrackingType.Bodyweight]: 'Bodyweight',
+};
+
 export interface Exercise {
   id: string;
   name: string;
@@ -40,6 +58,7 @@ export interface Exercise {
   equipment: Equipment;
   instructions: string | null;
   restSeconds: number | null;
+  trackingType: ExerciseTrackingType;
   isDefault: boolean;
   archivedAt: string | null;
   createdAt: string;
@@ -52,4 +71,5 @@ export interface ExerciseSeed {
   equipment: Equipment;
   instructions: string | null;
   restSeconds?: number | null;
+  trackingType?: ExerciseTrackingType;
 }

--- a/src/shared/types/split.ts
+++ b/src/shared/types/split.ts
@@ -1,4 +1,5 @@
 /** Split types - workout split planning (ordered workout/rest days applied for N cycles). */
+import type { ExerciseTrackingType } from '@shared/types/exercise';
 
 export type SplitDayType = 'workout' | 'rest';
 
@@ -41,6 +42,7 @@ export interface SeriesTemplateExercise {
   targetRepsMin: number | null;
   targetRepsMax: number | null;
   repGoalType: 'range' | 'amrap';
+  trackingType: ExerciseTrackingType;
   note: string | null;
   alternatives: { exerciseId: string; exerciseName: string }[];
 }

--- a/src/shared/types/workout.ts
+++ b/src/shared/types/workout.ts
@@ -1,4 +1,6 @@
 /** Workout types - TypeScript interfaces for Workout, WorkoutExercise, WorkoutSet, SupersetGroup, and related types. */
+import type { ExerciseTrackingType } from '@shared/types/exercise';
+
 export enum WorkoutStatus {
   InProgress = 'in_progress',
   Completed = 'completed',
@@ -111,6 +113,7 @@ export interface WorkoutFull extends Workout {
 export interface WorkoutExerciseFull extends WorkoutExercise {
   exerciseName: string;
   exerciseCategory: string;
+  trackingType: ExerciseTrackingType;
   /** Per-workout note for the currently-selected alternative (exercise option). */
   note: string | null;
   sets: WorkoutSet[];

--- a/src/shared/utils/formatting.ts
+++ b/src/shared/utils/formatting.ts
@@ -1,6 +1,7 @@
 /** Formatting utils - date formatting, duration display, and relative time helpers. */
 import { format, formatDistanceToNow, isToday, isYesterday } from 'date-fns';
 import type { UnitSystem } from '@shared/types/settings';
+import { ExerciseTrackingType } from '@shared/types/exercise';
 
 /** Parse a database timestamp (SQLite datetime('now') returns UTC without a suffix). */
 export function parseUTCTimestamp(timestamp: string): Date {
@@ -115,9 +116,20 @@ export function formatPrescription(
   sets: number | null,
   repsMin: number | null,
   repsMax: number | null,
-  repGoalType: 'range' | 'amrap' = 'range'
+  repGoalType: 'range' | 'amrap' = 'range',
+  trackingType: ExerciseTrackingType = ExerciseTrackingType.Weighted
 ): string {
   const setPart = sets != null ? `${sets} × ` : '';
+  if (trackingType === ExerciseTrackingType.Time) {
+    // Time exercises express the goal in seconds (or "max hold" for AMRAP).
+    if (repGoalType === 'amrap') return `${setPart}max hold`;
+    if (repsMin == null && repsMax == null) return sets != null ? `${sets} sets` : '—';
+    let secPart: string;
+    if (repsMax == null) secPart = `${repsMin}s+`;
+    else if (repsMin === repsMax) secPart = `${repsMin}s`;
+    else secPart = `${repsMin}-${repsMax}s`;
+    return `${setPart}${secPart}`;
+  }
   if (repGoalType === 'amrap') return `${setPart}AMRAP`;
   if (repsMin == null && repsMax == null) return sets != null ? `${sets} sets` : '—';
   let repPart: string;
@@ -125,6 +137,29 @@ export function formatPrescription(
   else if (repsMin === repsMax) repPart = `${repsMin}`;
   else repPart = `${repsMin}-${repsMax}`;
   return `${setPart}${repPart}`;
+}
+
+/**
+ * One-line summary of a logged set, adapting to how it was tracked:
+ *   weight+reps -> "80 kg × 8 reps"; bodyweight load -> "green band × 8 reps";
+ *   reps only -> "8 reps"; time (+distance) -> "45s" / "300s · 1000m"; empty -> "—".
+ */
+export function formatSetSummary(set: {
+  weightKg: number | null;
+  reps: number | null;
+  durationSeconds: number | null;
+  distanceMeters: number | null;
+  customFields: Record<string, unknown> | null;
+}): string {
+  const load = typeof set.customFields?.load === 'string' ? (set.customFields.load as string) : null;
+  if (set.weightKg != null && set.reps != null) return `${set.weightKg} kg × ${set.reps} reps`;
+  if (load && set.reps != null) return `${load} × ${set.reps} reps`;
+  if (load) return load;
+  if (set.reps != null) return `${set.reps} reps`;
+  if (set.durationSeconds != null) {
+    return `${set.durationSeconds}s${set.distanceMeters != null ? ` · ${set.distanceMeters}m` : ''}`;
+  }
+  return '—';
 }
 
 /** Calories, rounded to a whole number: 507.5 -> "508 kcal". */


### PR DESCRIPTION
Minor release **1.12.0**. Adds a per-exercise **Tracking** type so exercises can be logged in the way that fits them, independent of the workout type. Verified end-to-end on the Android emulator (incl. the in-place v20→v21 migration).

## Feature
A "Tracking" picker in the exercise editor with three options:
- **Weight × reps** — default; every existing exercise stays on this (no behavior change).
- **Bodyweight** — a free-text **load** field (`bw` / `green band` / `+5kg`) × reps.
- **Time** — a single **seconds** field with a start/stop **stopwatch** that fills the duration; AMRAP renders as "max hold".

## Implementation
- Migration → **schema v21**: adds `tracking_type` to `exercises` (existing rows default to `weighted`).
- **No new set columns** — reuses `workout_sets.duration_seconds` (time) and the `custom_fields` JSON (free-text load).
- `SetRow` / `ExerciseCard` / `SupersetCard` render inputs per the exercise's tracking type; the workout-history detail and split-template previews format the new set kinds via a shared `formatSetSummary`.
- Seeds mark Plank/Side Plank → time and Pull-Up/Chin-Up → bodyweight for fresh installs.

## Verification (emulator, with DB confirmation)
- Migration ran in place: `user_version=21`, column added, existing exercises defaulted to `weighted`, prior data preserved.
- Type picker persists (`tracking_type`); Time set logged via the stopwatch → `duration_seconds=26`; Bodyweight set → `custom_fields={"load":"green band"}`; history rendered "26s" and "green band". `tsc --noEmit` clean.

## Also included
- **`/e2e-test` project skill** (`.claude/skills/e2e-test`) — drives the app on the emulator and checks the important flows + edge cases, with an easy-to-extend checklist; gitignores machine-local `.claude/settings.local.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)